### PR TITLE
Make sure routes don't contain the site URL

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -187,7 +187,7 @@ class Generator
         $routes = $this->router->standardize($routes->all());
 
         return collect($routes)->map(function ($data, $url) {
-            return $this->createPage(new Route($url, $data));
+            return $this->createPage(new Route(URL::removeSiteUrl($url), $data));
         });
     }
 


### PR DESCRIPTION
This fixes an issue when you have a custom route and it saves the static file in a folder like this: `storage/app/statichttp/domain.com/` because the url contained the site url