### PR TITLE
Allow only recent content to be generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install the package using Composer:
 composer require statamic/ssg
 ```
 
-If you want or need to customize the way the site is generated, you can do so by publishing and modifying the config file with the following command: 
+If you want or need to customize the way the site is generated, you can do so by publishing and modifying the config file with the following command:
 
 ```
 php artisan vendor:publish --provider="Statamic\StaticSite\ServiceProvider"
@@ -38,6 +38,16 @@ php please ssg:generate
 
 Your site will be generated into a directory which you can deploy however you like. See [Deployment Examples](#deployment-examples) below for inspiration.
 
+### Generate recent content
+
+You may wish to sync only new content instead of generating the entire static site. You may use a `--recent` argument which generates collection content that's been updated in the last 24 hours. This only applies to new collection content and all Statamic pages will still be generated.
+
+```
+php please ssg:generate --recent
+php please ssg:generate --recent --since="1 month"
+```
+
+You may also use any additional time option `--since` if you want to use a custom time window.
 
 ## Routes
 

--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -21,7 +21,7 @@ class StaticSiteGenerate extends Command
      *
      * @var string
      */
-    protected $signature = 'statamic:ssg:generate';
+    protected $signature = 'statamic:ssg:generate {--recent} {--since=}';
 
     /**
      * The console command description.
@@ -51,6 +51,9 @@ class StaticSiteGenerate extends Command
     {
         Partyline::bind($this);
 
-        $this->generator->generate();
+        $recent = $this->option('recent');
+        $since = $this->option('since');
+
+        $this->generator->generate($recent, $since);
     }
 }

--- a/src/Page.php
+++ b/src/Page.php
@@ -25,6 +25,14 @@ class Page
         return $this->content->published();
     }
 
+    public function isRecent($recent, $since)
+    {
+        if (!$recent) return true;
+        if ($this->collection() === 'pages') return true;
+
+        return $this->content->updated_at > $since;
+    }
+
     public function generate($request)
     {
         try {
@@ -52,6 +60,11 @@ class Page
         $this->files->put($this->path(), $html);
 
         return new GeneratedPage($this, $response);
+    }
+
+    public function collection()
+    {
+        return $this->content->collectionHandle();
     }
 
     public function directory()


### PR DESCRIPTION
This allows you to specify a time window to generate content, for example you may only want to generate collection content that was updated in the last 24 hours (nightly deploys) or if you want to generate content with a custom time window.

This is useful for me as I can sync content to AWS S3 and it only syncs files that are new (without deleting old ones). This works well for my site because I have 8000+ journal entries going back to 1980s. To generate these with SSG takes 3+ hours, but with this new time window I can generate only the new updates in the last day (or longer) and sync them.

```
php please ssg:generate --recent
php please ssg:generate --recent --since
php please ssg:generate --recent --since="2 weeks"
php please ssg:generate --recent --since="1 month"
php please ssg:generate --recent --since="1 month and 4 days"
```

This will still generate pages in the default `pages` collection, and as `merge($this->urls())` has been moved to after merging content, you can also force content with a specific url even if it hasn't been updated recently (may be useful for testing).

For example, the ssg output if I use this would be:

```
$ php please ssg:generate --recent --since="3 days"

Generating collections updated in the last 3 days
[✔] /
[✔] /about
[✔] /about/history
[✔] /connect
[✔] /copyright
[✔] /journals
[✔] /journals/2020/08/03    // new content
[✔] /journals/2020/08/02    // new content
[✔] /journals/2020/08/01    // new content
[✔] /connect
[✔] /news
[✔] /news/racial-injustice   // content updated recently
[✔] /library/interviews
[✔] /library/interviews/qa-in-rome             // new content
[✔] /library/interviews/the-pizza-revolution   // edited recently
```