### PR TITLE
Allow wildcards in excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install the package using Composer:
 composer require statamic/ssg
 ```
 
-If you want or need to customize the way the site is generated, you can do so by publishing and modifying the config file with the following command: 
+If you want or need to customize the way the site is generated, you can do so by publishing and modifying the config file with the following command:
 
 ```
 php artisan vendor:publish --provider="Statamic\StaticSite\ServiceProvider"
@@ -50,6 +50,14 @@ Routes will not automatically be generated. You can add any additional URLs you 
 ],
 ```
 
+You can also exclude single routes, or route groups with wildcards. This will override anything in the `urls` config.
+
+``` php
+'exclude' => [
+    '/secret-page',
+    '/cheat-codes/*',
+],
+```
 
 ## Post-generation callback
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -172,6 +172,12 @@ class Generator
             ->merge($this->content())
             ->values()
             ->reject(function ($page) {
+                foreach ($this->config['exclude'] as $url) {
+                    if (Str::endsWith($url, '*')) {
+                        if (Str::is($url, $page->url())) return true;
+                    }
+                }
+
                 return in_array($page->url(), $this->config['exclude']);
             })->sortBy(function ($page) {
                 return str_replace('/', '', $page->url());


### PR DESCRIPTION
I found this useful for testing SSG with lots of content, this allows you to exclude certain routes with wildcards.

In the config you can use wildcards as follows:

```
    'exclude' => [
        '/about/*',
        '*/articles/*',    // e.g. en/articles/slug or fr/articles/slug
        '/contact',        // non-wildcard page
        '/pod*',           // excludes podcasts and pod-racing
    ],
```