### PR TITLE
Update Netlify setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Deployments are triggered by committing to Git and pushing to GitHub.
 - Link the site to your desired GitHub repository
 - Add build command `php please ssg:generate`
 - Set publish directory `storage/app/static`
-- Add environment variable: `PHP_VERSION` `7.2`
+- Add environment variable: `PHP_VERSION` `7.4`
 
 After your site has an APP_URL...
 


### PR DESCRIPTION
When using `PHP_VERSION: 7.2`, I get the following error:

`mockery/mockery 1.4.2 requires php ^7.3 || ^8.0 -> your PHP version (7.2.32) does not satisfy that requirement.`

Switching to `7.4` fixes this.