### PR TITLE
Filter out entries without routing info

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -184,9 +184,15 @@ class Generator
 
     protected function entries()
     {
-        return Entry::all()->map(function ($content) {
-            return $this->createPage($content);
-        })->filter->isGeneratable();
+        return Entry::all()
+            ->reject(function ($entry) {
+                return is_null($entry->uri());
+            })
+            ->map(function ($content) {
+                return $this->createPage($content);
+            })
+            ->filter
+            ->isGeneratable();
     }
 
     protected function terms()


### PR DESCRIPTION
This fixes #26 and fixes #27 where entries without routes are generated overriding the homepage and excessively generating files. 
I'm unsure this should also be applied to `urls`/`terms`/`scopedTerms` and if there's a better approach than the one taken here.