### PR TITLE
Add a before hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Install the package using Composer:
 composer require statamic/ssg
 ```
 
-If you want or need to customize the way the site is generated, you can do so by publishing and modifying the config file with the following command: 
+If you want or need to customize the way the site is generated, you can do so by publishing and modifying the config file with the following command:
 
 ```
 php artisan vendor:publish --provider="Statamic\StaticSite\ServiceProvider"
@@ -50,6 +50,26 @@ Routes will not automatically be generated. You can add any additional URLs you 
 ],
 ```
 
+## Pre-generation callback
+
+If you want to executed code before generating the static site: to run commands that modify the config files for example.
+
+``` php
+use Statamic\StaticSite\Generator;
+use Statamic\Facades\Config;
+
+class AppServiceProvider extends Provider
+{
+    public function boot()
+    {
+        Generator::before(function () {
+            // eg. dynamically create custom pages for a collection
+            // $urls = Config::get('statamic.ssg.urls');
+            // Config::set('statamic.ssg.urls', array_merge($urls, $custom));
+        });
+    }
+}
+```
 
 ## Post-generation callback
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -25,6 +25,7 @@ class Generator
     protected $config;
     protected $request;
     protected $after;
+    protected $before;
     protected $count = 0;
     protected $skips = 0;
     protected $warnings = 0;
@@ -34,7 +35,13 @@ class Generator
     {
         $this->app = $app;
         $this->files = $files;
-        $this->config = config('statamic.ssg');
+    }
+
+    public function before($before)
+    {
+        $this->before = $before;
+
+        return $this;
     }
 
     public function after($after)
@@ -46,6 +53,12 @@ class Generator
 
     public function generate()
     {
+        if ($this->before) {
+            call_user_func($this->before);
+        }
+
+        $this->config = config('statamic.ssg');
+
         Site::setCurrent(Site::default()->handle());
 
         $this


### PR DESCRIPTION
I'm working on a Static Pagination solution, but it requires generating many *new* urls for each page. I need to create these dynamically based on the number of entries, pagination size, etc.

To generate the URLs I need to use some facades like `Entry` and `Term`, however you can't use these directly in the config files. This pull request allows you to hook into the generator before the config files are loaded, which allows you to modify the config and dynamically add new urls.

Hopefully it will also be useful for other purposes.