### PR TITLE
Support for both 3.0 and 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "statamic/cms": "3.0.*"
+        "statamic/cms": "^3.0 || ^3.1"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "statamic/cms": "^3.0 || ^3.1"
+        "statamic/cms": "3.0.* || 3.1.*"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0"


### PR DESCRIPTION
This PR updates the `statamic/cms` version constraint to support both Statamic 3.0 and Statamic 3.1.