### PR TITLE
Automatically register Statamic routes

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -251,16 +251,8 @@ class Generator
 
     protected function routes()
     {
-        $routes = $this->router->getRoutes();
-
-        $action = FrontendController::class.'@route';
-
-        if (! $routes->getByAction($action)) {
-            return collect();
-        }
-
-        return collect($routes->getRoutes())->filter(function ($route) use ($action) {
-            return $route->getActionName() === $action
+        return collect($this->router->getRoutes()->getRoutes())->filter(function ($route) {
+            return $route->getActionName() === FrontendController::class.'@route'
                 && ! Str::contains($route->uri(), '{');
         })->map(function ($route) {
             $url = URL::tidy(Str::start($route->uri(), $this->config['base_url'].'/'));

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -6,6 +6,7 @@ use Facades\Statamic\View\Cascade;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;
 use Statamic\Facades\Site;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -18,11 +19,13 @@ use Statamic\Contracts\Imaging\UrlBuilder;
 use League\Flysystem\Filesystem as Flysystem;
 use Wilderborn\Partyline\Facade as Partyline;
 use Illuminate\Contracts\Foundation\Application;
+use Statamic\Http\Controllers\FrontendController;
 
 class Generator
 {
     protected $app;
     protected $files;
+    protected $router;
     protected $config;
     protected $request;
     protected $after;
@@ -31,10 +34,11 @@ class Generator
     protected $warnings = 0;
     protected $viewPaths;
 
-    public function __construct(Application $app, Filesystem $files)
+    public function __construct(Application $app, Filesystem $files, Router $router)
     {
         $this->app = $app;
         $this->files = $files;
+        $this->router = $router;
         $this->config = config('statamic.ssg');
     }
 
@@ -173,6 +177,7 @@ class Generator
     protected function pages()
     {
         return collect()
+            ->merge($this->routes())
             ->merge($this->urls())
             ->merge($this->entries())
             ->merge($this->terms())
@@ -239,6 +244,25 @@ class Generator
     {
         return collect($this->config['urls'] ?? [])->map(function ($url) {
             $url = URL::tidy(Str::start($url, $this->config['base_url'].'/'));
+            return $this->createPage(new Route($url));
+        });
+    }
+
+    protected function routes()
+    {
+        $routes = $this->router->getRoutes();
+
+        $action = FrontendController::class.'@route';
+
+        if (! $routes->getByAction($action)) {
+            return collect();
+        }
+
+        return collect($routes->getRoutes())->filter(function ($route) use ($action) {
+            return $route->getActionName() === $action
+                && ! Str::contains($route->uri(), '{');
+        })->map(function ($route) {
+            $url = URL::tidy(Str::start($route->uri(), $this->config['base_url'].'/'));
             return $this->createPage(new Route($url));
         });
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -183,6 +183,7 @@ class Generator
             ->merge($this->terms())
             ->merge($this->scopedTerms())
             ->values()
+            ->unique->url()
             ->reject(function ($page) {
                 foreach ($this->config['exclude'] as $url) {
                     if (Str::endsWith($url, '*')) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -10,7 +10,7 @@ class ServiceProvider extends LaravelServiceProvider
     public function register()
     {
         $this->app->singleton(Generator::class, function ($app) {
-            return new Generator($app, $app['files']);
+            return new Generator($app, $app['files'], $app['router']);
         });
     }
 


### PR DESCRIPTION
Any `Route::statamic()` routes being used in your application will automatically be registered. You will no longer need to manually add them to the config file.

Only routes without wildcards will be automatically registered. If there's a wildcard, we can't know all the possibilities there will be.

```php
Route::statamic('/foo/bar'); // will be registered
Route::statamic('/foo/{bar}'); // will not
```

Closes #13 