### PR TITLE
Ability to add urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ You can also exclude single routes, or route groups with wildcards. This will ov
 You may optionally define extra steps to be executed after the site has been generated.
 
 ``` php
-use Statamic\StaticSite\Generator;
+use Statamic\StaticSite\SSG;
 
 class AppServiceProvider extends Provider
 {
     public function boot()
     {
-        Generator::after(function () {
+        SSG::after(function () {
             // eg. copy directory to some server
         });
     }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,25 @@ You can also exclude single routes, or route groups with wildcards. This will ov
 ],
 ```
 
+### Dynamically adding routes
+
+You may add URLs dynamically by providing a closure that returns an array to the `addUrls` method.
+
+```php
+use Statamic\StaticSite\SSG;
+
+class AppServiceProvider extends Provider
+{
+    public function boot()
+    {
+        SSG::addUrls(function () {
+            return ['/one', '/two'];
+        });
+    }
+}
+```
+
+
 ## Post-generation callback
 
 You may optionally define extra steps to be executed after the site has been generated.

--- a/src/SSG.php
+++ b/src/SSG.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Statamic\StaticSite;
+
+use Illuminate\Support\Facades\Facade;
+
+class SSG extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return Generator::class;
+    }
+}


### PR DESCRIPTION
This PR lets you add urls to the config dynamically.

```php
SSG::addUrls(function () {
    $items = Http::get('/external-api')->json();
    return collect($items)->map->url;
});
```

Closes #42
Closes #19


This PR also adds an `SSG` facade, which closes #21