### PR TITLE
Generate 404.html if view exists

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -254,6 +254,10 @@ class Generator
             return $closure();
         });
 
+        if (view()->exists('errors.404')) {
+            $extra[] = '/404';
+        }
+
         return collect($this->config['urls'] ?? [])->merge($extra)->map(function ($url) {
             $url = URL::tidy(Str::start($url, $this->config['base_url'].'/'));
             return $this->createPage(new Route($url));

--- a/src/Page.php
+++ b/src/Page.php
@@ -45,7 +45,7 @@ class Page
 
         $html = $response->getContent();
 
-        if (! $this->files->exists($this->directory())) {
+        if (! $this->is404() && ! $this->files->exists($this->directory())) {
             $this->files->makeDirectory($this->directory(), 0755, true);
         }
 
@@ -61,6 +61,10 @@ class Page
 
     public function path()
     {
+        if ($this->is404()) {
+            return $this->config['destination'] . '/404.html';
+        }
+
         return $this->directory()  . '/index.html';
     }
 
@@ -72,5 +76,10 @@ class Page
     public function site()
     {
         return $this->content->site();
+    }
+
+    public function is404()
+    {
+        return $this->url() === '/404';
     }
 }

--- a/src/Route.php
+++ b/src/Route.php
@@ -32,6 +32,10 @@ class Route
         $kernel->terminate($request, $response);
 
         if ($e = $response->exception) {
+            if ($response->status() === 404 && $this->url() === '/404') {
+                return $response;
+            }
+
             throw $e;
         }
 


### PR DESCRIPTION
Closes #33 

Netlify and Vercel both serve a 404 if there's a `404.html`. I assume other static site hosting platforms will follow suit.