### PR TITLE
Use URLs without redirects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "statamic/cms": "3.0.* || 3.1.*"
+        "statamic/cms": "~3.1.7"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0"

--- a/src/Page.php
+++ b/src/Page.php
@@ -70,7 +70,7 @@ class Page
 
     public function url()
     {
-        return $this->content->url();
+        return $this->content->urlWithoutRedirect();
     }
 
     public function site()

--- a/src/Route.php
+++ b/src/Route.php
@@ -20,6 +20,11 @@ class Route
         return URL::makeRelative($this->url);
     }
 
+    public function urlWithoutRedirect()
+    {
+        return $this->url();
+    }
+
     public function site()
     {
         return Site::findByUrl($this->url);


### PR DESCRIPTION
Fixes #41 

If an entry redirects to somewhere else, its `url()` would be the url of the destination.

```yaml
id: 1
redirect: /entry/2
```

```yaml
id: 2
```

So, when the SSG compiled all the URLs, the first entry would take the url of the second, but output the response as if it were the first. You'd end up with a file at the destination redirecting to itself.

```
[!] /entry/2 (Resulted in a redirect to http://localhost/entry/2)
```

This PR uses `urlWithoutRedirect`, which maintains the original urls.

```
[!] /entry/1 (Resulted in a redirect to http://localhost/entry/2)
[✔] /entry/2
```

Because this method was introduced in 3.1.7, the composer requirement has been bumped. (Technically it was bumped in #53)