### PR TITLE
Add tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,57 @@
+name: Run Tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  php-tests:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        php: [7.4, 7.3, 7.2, 8.0]
+        laravel: [8.*, 7.*, 6.*]
+        dependency-version: [prefer-lowest, prefer-stable]
+        os: [ubuntu-20.04]
+        include:
+          - laravel: 8.*
+            testbench: 6.*
+            laravel-constraint: ^8.18.1
+          - laravel: 7.*
+            testbench: 5.*
+          - laravel: 6.*
+            testbench: 4.*
+            laravel-constraint: ^6.6.2
+          - php: 7.4
+            dependency-version: prefer-lowest
+            additional-deps: '"mockery/mockery:>=1.2.3"'
+          - php: 8.0
+            dependency-version: prefer-lowest
+            additional-deps: '"mockery/mockery:>=1.3.3"'
+        exclude:
+          - laravel: 8.*
+            php: 7.2
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel-constraint || matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" ${{ matrix.additional-deps }} --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "statamic/cms": "3.0.* || 3.1.*"
+        "statamic/cms": "~3.1.7"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0"

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -12,14 +12,14 @@ use Statamic\StaticSite\Request;
 class RequestTest extends TestCase
 {
     /** @test */
-    function gets_scheme()
+    public function gets_scheme()
     {
         $this->assertEquals('http', (new Request)->setConfig(['base_url' => 'http://test.com'])->getScheme());
         $this->assertEquals('https', (new Request)->setConfig(['base_url' => 'https://test.com'])->getScheme());
     }
 
     /** @test */
-    function gets_http_host()
+    public function gets_http_host()
     {
         $this->assertEquals('test.com', (new Request)->setConfig(['base_url' => 'http://test.com'])->getHttpHost());
         $this->assertEquals('test.com', (new Request)->setConfig(['base_url' => 'http://test.com/'])->getHttpHost());
@@ -28,7 +28,7 @@ class RequestTest extends TestCase
     }
 
     /** @test */
-    function gets_base_url()
+    public function gets_base_url()
     {
         $this->assertEquals('', (new Request)->setConfig(['base_url' => 'http://test.com'])->getBaseUrl());
         $this->assertEquals('', (new Request)->setConfig(['base_url' => 'http://test.com/'])->getBaseUrl());
@@ -37,13 +37,13 @@ class RequestTest extends TestCase
     }
 
     /** @test */
-    function gets_path()
+    public function gets_path()
     {
         // The current site needs to be explicitly set, otherwise it will try to
         // resolve it from the request, which will result in an infinite loop.
         Site::setCurrent(Site::default()->handle());
 
-        Collection::make('test')->route('{slug}')->save();
+        Collection::make('test')->routes('{slug}')->save();
         $entry = Entry::make()->slug('foo')->locale('default')->collection('test');
         $page = new Page(app('files'), [], $entry);
 


### PR DESCRIPTION
Runs the test suite in GitHub actions.

Also bumps the requirement to 3.1.7 which is going to happen in #52 anyway, rather than mess around with other ways to get the tests passing.