### PR TITLE
Generate files concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ php please ssg:generate
 
 Your site will be generated into a directory which you can deploy however you like. See [Deployment Examples](#deployment-examples) below for inspiration.
 
+### Multiple Workers
+
+For improved performance, you may spread the page generation across multiple workers. This requires Spatie's [Fork](https://github.com/spatie/fork) package. Then you may specify how many workers are to be used. You can use as many workers as you have CPU cores.
+
+```
+composer require spatie/fork
+php please ssg:generate --workers=4
+```
+
 
 ## Routes
 

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,13 @@
         }
     },
     "require": {
-        "statamic/cms": "~3.1.7",
-        "spatie/fork": "^0.0.4"
+        "statamic/cms": "~3.1.7"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0"
+    },
+    "suggest": {
+        "spatie/fork": "Required to generate pages concurrently (^0.0.4)."
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         }
     },
     "require": {
-        "statamic/cms": "~3.1.7"
+        "statamic/cms": "~3.1.7",
+        "spatie/fork": "^0.0.4"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0"

--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -21,7 +21,7 @@ class StaticSiteGenerate extends Command
      *
      * @var string
      */
-    protected $signature = 'statamic:ssg:generate';
+    protected $signature = 'statamic:ssg:generate {--workers=1}';
 
     /**
      * The console command description.
@@ -51,6 +51,8 @@ class StaticSiteGenerate extends Command
     {
         Partyline::bind($this);
 
-        $this->generator->generate();
+        $this->generator
+            ->workers($this->option('workers'))
+            ->generate();
     }
 }

--- a/src/ConcurrentTasks.php
+++ b/src/ConcurrentTasks.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Statamic\StaticSite;
+
+use Spatie\Fork\Fork;
+
+class ConcurrentTasks implements Tasks
+{
+    protected $fork;
+
+    public function __construct(Fork $fork)
+    {
+        $this->fork = $fork;
+    }
+
+    public function run(...$closures)
+    {
+        return $this->fork->run(...$closures);
+    }
+}

--- a/src/ConsecutiveTasks.php
+++ b/src/ConsecutiveTasks.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Statamic\StaticSite;
+
+class ConsecutiveTasks implements Tasks
+{
+    public function run(...$closures)
+    {
+        $results = [];
+
+        foreach ($closures as $closure) {
+            $results[] = $closure();
+        }
+
+        return $results;
+    }
+}

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -35,6 +35,7 @@ class Generator
     protected $warnings = 0;
     protected $viewPaths;
     protected $extraUrls;
+    protected $workers = 1;
 
     public function __construct(Application $app, Filesystem $files, Router $router)
     {
@@ -54,6 +55,13 @@ class Generator
         }
 
         return $config;
+    }
+
+    public function workers(int $workers)
+    {
+        $this->workers = $workers;
+
+        return $this;
     }
 
     public function after($after)
@@ -213,9 +221,7 @@ class Generator
 
     protected function makeContentGenerationClosures($pages, $request)
     {
-        $processes = 1;
-
-        return $pages->split($processes)->map(function ($pages) use ($request) {
+        return $pages->split($this->workers)->map(function ($pages) use ($request) {
             return function () use ($pages, $request) {
                 $count = $skips = $warnings = 0;
                 $errors = [];

--- a/src/NotGeneratedException.php
+++ b/src/NotGeneratedException.php
@@ -43,6 +43,6 @@ class NotGeneratedException extends \Exception
                 $message = $this->getMessage();
         }
 
-        return sprintf('%s %s (%s)', "\x1B[1A\x1B[2K<fg=red>[✘]</>", $this->getPage()->url(), $message);
+        return sprintf('%s %s (%s)', "<fg=red>[✘]</>", $this->getPage()->url(), $message);
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\StaticSite;
 
+use Spatie\Fork\Fork;
 use Statamic\StaticSite\Generator;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 
@@ -9,8 +10,14 @@ class ServiceProvider extends LaravelServiceProvider
 {
     public function register()
     {
+        $this->app->bind(Tasks::class, function () {
+            return class_exists(Fork::class)
+                ? new ConcurrentTasks(new Fork)
+                : new ConsecutiveTasks;
+        });
+
         $this->app->singleton(Generator::class, function ($app) {
-            return new Generator($app, $app['files'], $app['router']);
+            return new Generator($app, $app['files'], $app['router'], $app[Tasks::class]);
         });
     }
 

--- a/src/Tasks.php
+++ b/src/Tasks.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Statamic\StaticSite;
+
+interface Tasks
+{
+    public function run(...$closures);
+}

--- a/tests/ConcurrentTasksTest.php
+++ b/tests/ConcurrentTasksTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests;
+
+use Spatie\Fork\Fork;
+use Statamic\StaticSite\ConcurrentTasks;
+
+class ConcurrentTasksTest extends TestCase
+{
+    /** @test */
+    public function it_runs_callbacks()
+    {
+        $one = function () {
+            return 'one';
+        };
+
+        $two = function () {
+            return 'two';
+        };
+
+        $fork = $this->mock(Fork::class);
+        $fork->shouldReceive('run')->once()->with($one, $two)->andReturn([$one(), $two()]);
+
+        $results = (new ConcurrentTasks($fork))->run($one, $two);
+
+        $this->assertEquals(['one', 'two'], $results);
+    }
+}

--- a/tests/ConsecutiveTasksTest.php
+++ b/tests/ConsecutiveTasksTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests;
+
+use Statamic\StaticSite\ConsecutiveTasks;
+
+class ConsecutiveTasksTest extends TestCase
+{
+    /** @test */
+    public function it_runs_callbacks()
+    {
+        $callbacksRan = 0;
+
+        $one = function () use (&$callbacksRan) {
+            $callbacksRan++;
+            return 'one';
+        };
+
+        $two = function () use (&$callbacksRan) {
+            $callbacksRan++;
+            return 'two';
+        };
+
+        $results = (new ConsecutiveTasks)->run($one, $two);
+
+        $this->assertEquals(['one', 'two'], $results);
+        $this->assertEquals(2, $callbacksRan);
+    }
+}


### PR DESCRIPTION
This PR uses Spatie's [fork](https://github.com/spatie/fork) package to split the content file generation into as many chunks as you request. Each chunk will run at the same time.

You must have `spatie/fork` installed, which requires PHP 8.

```
composer require spatie/fork
```

You can specify how many "workers" should be used with an option.

```
php please ssg:generate --workers=4
```

Each worker will spawn a separate PHP process, so you should only use as many workers as you have CPU cores.

The console output has been adjusted a little to cope with the concurrency. Rather than output each line, you get a single line that is constantly updating, and you will see all the errors right at the end.

![image](https://user-images.githubusercontent.com/105211/116341725-688b3100-a7af-11eb-86d4-df9c3cbb650d.png)

If you don't have `spatie/fork` installed, it'll tell you:

![image](https://user-images.githubusercontent.com/105211/116341194-77bdaf00-a7ae-11eb-9095-eb2c7b622c16.png)

If you use `--workers=1` (for some reason) or don't specify the option at all, it'll happily just chug along without concurrency.

Fixes #16 