### PR TITLE
Shuffle pages

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -218,9 +218,7 @@ class Generator
                 }
 
                 return in_array($page->url(), $this->config['exclude']);
-            })->sortBy(function ($page) {
-                return str_replace('/', '', $page->url());
-            });
+            })->shuffle();
     }
 
     protected function makeContentGenerationClosures($pages, $request)


### PR DESCRIPTION
In #54 you can split your pages into chunks to be processed concurrently.

If you have a bunch of similar entries that happen to be slow, or a bunch of manual slow routes, they'll all be grouped together. It's possible one worker will get stuck with a bunch of slow pages, and the other workers will be finished.

By shuffling all the pages, it gives you a better chance that the slow routes will be spread across workers, making the site generate faster overall.

Previously we sorted by URL purely to make the console output nicer. It didn't affect the functionality.