### PR TITLE
Support generating non-html files

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -45,7 +45,7 @@ class Page
 
         $html = $response->getContent();
 
-        if (! $this->is404() && ! $this->files->exists($this->directory())) {
+        if (! $this->files->exists($this->directory())) {
             $this->files->makeDirectory($this->directory(), 0755, true);
         }
 
@@ -56,7 +56,7 @@ class Page
 
     public function directory()
     {
-        return $this->config['destination'] . $this->url();
+        return dirname($this->path());
     }
 
     public function path()
@@ -65,7 +65,17 @@ class Page
             return $this->config['destination'] . '/404.html';
         }
 
-        return $this->directory()  . '/index.html';
+        $url = $this->url();
+
+        $ext = pathinfo($url, PATHINFO_EXTENSION) ?: 'html';
+
+        $url = $this->config['destination'] . $url;
+
+        if ($ext === 'html') {
+            $url .= '/index.html';
+        }
+
+        return $url;
     }
 
     public function url()

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Filesystem\Filesystem;
+use Mockery;
+use Statamic\Contracts\Entries\Entry;
+use Statamic\StaticSite\Page;
+
+class PageTest extends TestCase
+{
+    /** @test */
+    public function it_gets_the_path()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('urlWithoutRedirect')->andReturn('/foo/bar');
+
+        $page = $this->page($entry, ['destination' => '/path/to/static']);
+
+        $this->assertEquals('/path/to/static/foo/bar/index.html', $page->path());
+        $this->assertEquals('/path/to/static/foo/bar', $page->directory());
+    }
+
+    /** @test */
+    public function it_gets_the_path_of_a_url_with_a_file_extension()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('urlWithoutRedirect')->andReturn('/foo/bar/sitemap.xml');
+
+        $page = $this->page($entry, ['destination' => '/path/to/static']);
+
+        $this->assertEquals('/path/to/static/foo/bar/sitemap.xml', $page->path());
+        $this->assertEquals('/path/to/static/foo/bar', $page->directory());
+    }
+
+    /** @test */
+    public function it_gets_the_path_of_the_404_url()
+    {
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('urlWithoutRedirect')->andReturn('/404');
+
+        $page = $this->page($entry, ['destination' => '/path/to/static']);
+
+        $this->assertEquals('/path/to/static/404.html', $page->path());
+        $this->assertEquals('/path/to/static', $page->directory());
+    }
+
+    private function page($entry, $config)
+    {
+        return new Page($this->mock(Filesystem::class), $config, $entry);
+    }
+}


### PR DESCRIPTION
Closes #62 

When the URL has a file extension, it'll generate it as-is. e.g. `/path/to/sitemap.xml`

Otherwise, it'll assume it's an html file, and will continue to do `/path/to/slug/index.html`