### PR TITLE
Process results to handle Skips and Warnings.

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -184,6 +184,8 @@ class Generator
 
         $results = $this->tasks->run(...$closures);
 
+        $results = $this->processResults($results);
+        
         $this->outputResults($results);
 
         return $this;
@@ -257,13 +259,22 @@ class Generator
         })->all();
     }
 
-    protected function outputResults($results)
+    protected function processResults($results)
     {
         $results = collect($results);
 
-        Partyline::line("\x1B[1A\x1B[2K<info>[✔]</info> Generated {$results->sum('count')} content files");
+        $this->count = $results->sum('count');
+        $this->skips = $results->sum('skips');
+        $this->warnings = $results->sum('warnings');
 
-        if ($results->sum('skips')) {
+        return $results;
+    }
+
+    protected function outputResults($results)
+    {
+        Partyline::line("\x1B[1A\x1B[2K<info>[✔]</info> Generated {$this->count} content files");
+
+        if ($this->skips) {
             $results->reduce(function ($carry, $item) {
                 return $carry->merge($item['errors']);
             }, collect())->each(function ($error) {


### PR DESCRIPTION
At the moment the Generate function looks for `$this->skips` and `$this->warnings` but they're never assigned a value. This update sums the results after the workers finish processing the site and assign the values. This is required if you want to fail on errors as highlighted in #70.