### PR TITLE
Basic failure on errors

### DIFF
--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -21,7 +21,7 @@ class StaticSiteGenerate extends Command
      *
      * @var string
      */
-    protected $signature = 'statamic:ssg:generate {--workers=}';
+    protected $signature = 'statamic:ssg:generate {--workers=} {--failsafe}';
 
     /**
      * The console command description.
@@ -55,8 +55,11 @@ class StaticSiteGenerate extends Command
             $this->comment('You may be able to speed up site generation significantly by installing spatie/fork and using multiple workers (requires PHP 8+).');
         }
 
+        $failsafe = $this->option('failsafe');
+
         $this->generator
             ->workers($workers ?? 1)
+            ->failmode($failsafe)
             ->generate();
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -37,6 +37,7 @@ class Generator
     protected $viewPaths;
     protected $extraUrls;
     protected $workers = 1;
+    protected $failsafe;
 
     public function __construct(Application $app, Filesystem $files, Router $router, Tasks $tasks)
     {
@@ -62,6 +63,13 @@ class Generator
     public function workers(int $workers)
     {
         $this->workers = $workers;
+
+        return $this;
+    }
+
+    public function failmode(bool $failsafe)
+    {
+        $this->failsafe = $failsafe;
 
         return $this;
     }
@@ -100,6 +108,11 @@ class Generator
 
         if ($this->warnings) {
             Partyline::warn("[!] {$this->warnings}/{$this->count} pages generated with warnings");
+        }
+
+        if ($this->failsafe && ($this->warnings || $this->skips)) {
+            Partyline::error('Failed to generate static site without errors.');
+            die();
         }
 
         if ($this->after) {


### PR DESCRIPTION
This is a draft to get some feedback on handling errors and failing correctly to stop a CI pipeline if something goes wrong, as described in #70. This adds a new option `--failsafe` to the command that will die the SSG process after generating all the pages. This allows you to view all the errors printed in the console instead of failing on the first occurrence of an error.

It works on warnings or skips now, but may need additional handling to deal with page rendering errors or "inline errors". For instance a Glide error as described in #70 may return a `200 Success` response but the rendered page may not contain the appropriate images..? I'm not sure if Statamic requires some modification to catch these render errors. However, this basic modification should provide some safety against SSG errors.

If you don't provide `--failsafe` then SSG will continue as normal.

- [ ] This pull request requires #71 so we can correctly count the errors.
