### PR TITLE
Warnings, Skips, and Failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ class AppServiceProvider extends Provider
 }
 ```
 
+
+## Triggering Command Failures
+
+If you are using the SSG in a CI environment, you may want to prevent the command from succeeding if any pages aren't generated (e.g. to prevent deployment of an incomplete site).
+
+By default, the command will finish and exit with a success code even if there were un-generated pages. You can tell configure the SSG to fail early on errors, or even on warnings.
+
+```php
+'failures' => 'errors', // or 'warnings'
+```
+
+
 ## Deployment Examples
 
 These examples assume your workflow will be to author content **locally** and _not_ using the control panel in production.

--- a/config/ssg.php
+++ b/config/ssg.php
@@ -90,4 +90,17 @@ return [
         'directory' => 'img',
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Failures
+    |--------------------------------------------------------------------------
+    |
+    | You may configure whether the console command will exit early with a
+    | failure status code when it encounters errors or warnings. You may
+    | want to do this to prevent deployments in CI environments, etc.
+    |
+    */
+
+    'failures' => false, // 'errors' or 'warnings'
+
 ];

--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -5,6 +5,7 @@ namespace Statamic\StaticSite\Commands;
 use Illuminate\Console\Command;
 use Statamic\StaticSite\Generator;
 use Statamic\Console\RunsInPlease;
+use Statamic\StaticSite\GenerationFailedException;
 use Wilderborn\Partyline\Facade as Partyline;
 
 class StaticSiteGenerate extends Command
@@ -55,8 +56,16 @@ class StaticSiteGenerate extends Command
             $this->comment('You may be able to speed up site generation significantly by installing spatie/fork and using multiple workers (requires PHP 8+).');
         }
 
-        $this->generator
-            ->workers($workers ?? 1)
-            ->generate();
+        try {
+            $this->generator
+                ->workers($workers ?? 1)
+                ->generate();
+        } catch (GenerationFailedException $e) {
+            $this->line($e->getConsoleMessage());
+            $this->error('Static site generation failed.');
+            return 1;
+        }
+
+        return 0;
     }
 }

--- a/src/GenerationFailedException.php
+++ b/src/GenerationFailedException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Statamic\StaticSite;
+
+class GenerationFailedException extends \Exception
+{
+    private $consoleMessage;
+
+    public static function withConsoleMessage($message)
+    {
+        return (new static)->setConsoleMessage($message);
+    }
+
+    public function setConsoleMessage($message)
+    {
+        $this->consoleMessage = $message;
+
+        return $this;
+    }
+
+    public function getConsoleMessage()
+    {
+        return $this->consoleMessage;
+    }
+}


### PR DESCRIPTION
You can now have the command exit with a failure status code, useful for CI deployments.

In your `config/statamic/ssg.php` you can set whether to fail on `errors` or `warnings` (which includes errors).

```php
'failures' => false, // 'errors' or 'warnings'
```

Here's what you'd see with failures enabled:

![image](https://user-images.githubusercontent.com/105211/136453108-f4d5009a-666e-46f1-9835-94132cff6cdd.png)

With them disabled (the default):

![image](https://user-images.githubusercontent.com/105211/136453242-3199a88f-6e80-4c7f-afb1-5932dee3d36d.png)


On my terminal, the color of the next prompt is the exit code.
The first command exited with a failure code, so it's red. The second one succeeded, so it's green.

When failures are disabled, you'll see the errors and warnings inline, then a summary.

Closes #70 
Closes #71 
Closes #72 