### PR TITLE
Make reusing Glide cache directory easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,28 @@ By default, the command will finish and exit with a success code even if there w
 ```php
 'failures' => 'errors', // or 'warnings'
 ```
+## Reusing Glide generated cache output
 
+You may see slow build times for pages that load faster in other environments if you have multiple image manipulations going on with Glide.
+
+To reuse the Glide cache you can use the `copy` or `symlinks` config options to add `storage/app/static/img` contents from somewhere else in the build system, and the generator will use that cache.
+
+If you are using Netlify, you can also utilize [netlify-plugin-cache](https://github.com/jakejarvis/netlify-plugin-cache) plugin to automatically restore and save directories:
+
+1. [Install the plugin into your project](https://docs.netlify.com/configure-builds/build-plugins/#file-based-installation)
+2. Add the following code in your [netlify.toml](https://docs.netlify.com/configure-builds/file-based-configuration/) file:
+```toml
+[[plugins]]
+package = "netlify-plugin-cache"
+
+  [plugins.inputs]
+  # This is default Glide image cache directory for SSG.
+  # Make sure the path matches with `directory` and `glide.directory` config options from `ssg.php` config file
+  paths = ["storage/app/static/img"]
+```
+3. Set `clear_destination_directory` to `false`, this is because by default the generator clears the SSG output directory when the generator starts, and the Netlify plugin restores the cached directories *before* this SSG generation step.
+
+Commit the changes and deploy! After the first initial deploy, the subsequent builds should see a significant decrease in build times.
 
 ## Deployment Examples
 

--- a/config/ssg.php
+++ b/config/ssg.php
@@ -28,6 +28,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Clear Destination Directory
+    |--------------------------------------------------------------------------
+    |
+    | This option defines if the destination directory should be cleared when
+    | running the generator.
+    |
+    */
+    'clear_destination_directory' => env('SSG_CLEAR_DESTINATION_DIRECTORY', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Files and Symlinks
     |--------------------------------------------------------------------------
     |

--- a/config/ssg.php
+++ b/config/ssg.php
@@ -20,21 +20,13 @@ return [
     | Destination Directory
     |--------------------------------------------------------------------------
     |
-    | This option defines where the static files will be saved.
+    | This option defines where the static files will be saved, and whether
+    | or not it should get cleared out before generating the new files.
     |
     */
 
     'destination' => storage_path('app/static'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Clear Destination Directory
-    |--------------------------------------------------------------------------
-    |
-    | This option defines if the destination directory should be cleared when
-    | running the generator.
-    |
-    */
     'clear_destination_directory' => env('SSG_CLEAR_DESTINATION_DIRECTORY', true),
 
     /*

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -84,8 +84,13 @@ class Generator
 
         $this
             ->bindGlide()
-            ->backupViewPaths()
-            ->clearDirectory()
+            ->backupViewPaths();
+
+        if ($this->config['clear_destination_directory'] === true) {
+            $this->clearDirectory();
+        }
+
+        $this
             ->createSymlinks()
             ->copyFiles()
             ->createContentFiles()
@@ -127,10 +132,6 @@ class Generator
 
     public function clearDirectory()
     {
-        if ($this->config['clear_destination_directory'] === false) {
-            return $this;
-        }
-
         $this->files->deleteDirectory($this->config['destination'], true);
 
         return $this;

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -84,8 +84,13 @@ class Generator
 
         $this
             ->bindGlide()
-            ->backupViewPaths()
-            ->clearDirectory()
+            ->backupViewPaths();
+
+        if ($this->config['clear_destination_directory'] === true) {
+            $this->clearDirectory();
+        }
+
+        $this
             ->createContentFiles()
             ->createSymlinks()
             ->copyFiles()

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -91,9 +91,9 @@ class Generator
         }
 
         $this
-            ->createContentFiles()
             ->createSymlinks()
             ->copyFiles()
+            ->createContentFiles()
             ->outputSummary();
 
         if ($this->after) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -84,13 +84,8 @@ class Generator
 
         $this
             ->bindGlide()
-            ->backupViewPaths();
-
-        if ($this->config['clear_destination_directory'] === true) {
-            $this->clearDirectory();
-        }
-
-        $this
+            ->backupViewPaths()
+            ->clearDirectory()
             ->createSymlinks()
             ->copyFiles()
             ->createContentFiles()
@@ -132,6 +127,10 @@ class Generator
 
     public function clearDirectory()
     {
+        if ($this->config['clear_destination_directory'] === false) {
+            return $this;
+        }
+
         $this->files->deleteDirectory($this->config['destination'], true);
 
         return $this;


### PR DESCRIPTION
This PR helps improve the situation with these two issues https://github.com/statamic/ssg/issues/55 https://github.com/statamic/ssg/issues/56

Most of my thinking is already written in #55 but I will outline it again. I have made reusing Glide cache directory easier by:
1. Moving content generation step *after* files/dirs have been copied or symlinked.
2. Allow to skip clearing SSG output directory via config option

Both things give more freedom for developers to move/copy/symlink any content in the output directory. First one is useful if you are just using the `ssg.php` config file to copy the cache. The second one is useful if you are copying cache *outside* and *before* the `ssg:generate` step.

There is no issue with Glide/Flysystem as Jason initially thought (phew!)

I also added instructions on how to reuse cache easily on Netlify. I do this for one of my sites already and I saw about 66% decrease in build times. :rocket:  I have a lot of Glide manipulations. 