### PR TITLE
Explicitly use the request in the cascade

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -176,7 +176,11 @@ class Generator
 
     protected function createContentFiles()
     {
-        $request = $this->makeRequest();
+        $request = tap(Request::capture(), function ($request) {
+            $request->setConfig($this->config);
+            $this->app->instance('request', $request);
+            Cascade::withRequest($request);
+        });
 
         $pages = $this->gatherContent();
 
@@ -388,18 +392,6 @@ class Generator
     protected function createPage($content)
     {
         return new Page($this->files, $this->config, $content);
-    }
-
-    protected function makeRequest()
-    {
-        $request = tap(Request::capture(), function ($request) {
-            $request->setConfig($this->config);
-            $this->app->instance('request', $request);
-        });
-
-        Cascade::withRequest($request);
-
-        return $request;
     }
 
     protected function updateCurrentSite($site)

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -176,10 +176,7 @@ class Generator
 
     protected function createContentFiles()
     {
-        $request = tap(Request::capture(), function ($request) {
-            $request->setConfig($this->config);
-            $this->app->instance('request', $request);
-        });
+        $request = $this->makeRequest();
 
         $pages = $this->gatherContent();
 
@@ -391,6 +388,18 @@ class Generator
     protected function createPage($content)
     {
         return new Page($this->files, $this->config, $content);
+    }
+
+    protected function makeRequest()
+    {
+        $request = tap(Request::capture(), function ($request) {
+            $request->setConfig($this->config);
+            $this->app->instance('request', $request);
+        });
+
+        Cascade::withRequest($request);
+
+        return $request;
     }
 
     protected function updateCurrentSite($site)


### PR DESCRIPTION
Fixes #107
Fixes #106

The fake ssg request was being used in the cascade by fluke. We should set it explicitly anyway.
