### PR TITLE
Fix date to string format

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\StaticSite;
 
+use Carbon\Carbon;
 use Spatie\Fork\Fork;
+use Statamic\Statamic;
 use Facades\Statamic\View\Cascade;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;
@@ -258,6 +260,12 @@ class Generator
                 $errors = [];
 
                 foreach ($pages as $page) {
+                    $oldCarbonFormat = (new \ReflectionClass(Carbon::class))->getStaticPropertyValue('toStringFormat');
+
+                    if ($this->shouldSetCarbonFormat($page)) {
+                        Carbon::setToStringFormat(Statamic::dateFormat());
+                    }
+
                     $this->updateCurrentSite($page->site());
 
                     view()->getFinder()->setPaths($this->viewPaths);
@@ -277,6 +285,8 @@ class Generator
 
                         $errors[] = $e->consoleMessage();
                         continue;
+                    } finally {
+                        Carbon::setToStringFormat($oldCarbonFormat);
                     }
 
                     if ($generated->hasWarning()) {
@@ -385,7 +395,7 @@ class Generator
                 && ! Str::contains($route->uri(), '{');
         })->map(function ($route) {
             $url = URL::tidy(Str::start($route->uri(), $this->config['base_url'].'/'));
-            return $this->createPage(new Route($url));
+            return $this->createPage(new StatamicRoute($url));
         });
     }
 
@@ -423,5 +433,14 @@ class Generator
         }
 
         return $config === 'warnings';
+    }
+
+    protected function shouldSetCarbonFormat($page)
+    {
+        $content = $page->content();
+
+        return $content instanceof \Statamic\Contracts\Entries\Entry
+            || $content instanceof \Statamic\Contracts\Taxonomies\Term
+            || $content instanceof StatamicRoute;
     }
 }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -260,6 +260,7 @@ class Generator
                 $errors = [];
 
                 foreach ($pages as $page) {
+                    // There is no getter method, so use reflection.
                     $oldCarbonFormat = (new \ReflectionClass(Carbon::class))->getStaticPropertyValue('toStringFormat');
 
                     if ($this->shouldSetCarbonFormat($page)) {

--- a/src/Page.php
+++ b/src/Page.php
@@ -20,6 +20,11 @@ class Page
         $this->content = $content;
     }
 
+    public function content()
+    {
+        return $this->content;
+    }
+
     public function isGeneratable()
     {
         return $this->content->published();

--- a/src/StatamicRoute.php
+++ b/src/StatamicRoute.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Statamic\StaticSite;
+
+class StatamicRoute extends Route
+{
+    //
+}


### PR DESCRIPTION
Fixes #77 

As per [this comment](https://github.com/statamic/ssg/issues/77#issuecomment-1210901155) the date format gets set in a middleware, but middlewares aren't run.

This is a shorter term solution. If/when we eventually run the appropriate middleware, this PR can be reverted.

Also adds a StatamicRoute class just so it's easier to differentiate between a Route::get() and Route::statamic().