### PR TITLE
Support Statamic v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,24 +12,16 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.0, 8.1]
-        laravel: [8.*, 9.*]
+        php: [8.0, 8.1, 8.2]
+        laravel: [9.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
           - os: windows-latest
-            php: 7.4
-            laravel: 8.*
-            framework: ^8.65.0
-            stability: prefer-stable
-          - os: windows-latest
             php: 8.1
-            laravel: 9.*
+            laravel: 10.*
             framework: ^9.0
             stability: prefer-stable
-        exclude:
-          - laravel: 9.*
-            php: 7.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,15 @@ jobs:
         include:
           - os: windows-latest
             php: 8.1
-            laravel: 10.*
-            framework: ^9.0
+            laravel: 9.*
             stability: prefer-stable
+          - os: windows-latest
+            php: 8.1
+            laravel: 10.*
+            stability: prefer-stable
+        exclude:
+          - php: 8.0
+            laravel: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "statamic/cms": "~3.3.54 || ~3.4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.22.0 || ^7.0"
+        "orchestra/testbench": "^7.0 || ^8.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "statamic/cms": "~3.3.54 || ~3.4.0"
+        "statamic/cms": "^4.0"
     },
     "require-dev": {
         "orchestra/testbench": "^7.0 || ^8.0"


### PR DESCRIPTION
## What's new

- Add Statamic 4 support 🎉
- Add Laravel 10 support

## Major changes

- Statamic 3.3 and 3.4 are no longer supported.
- Laravel 8 is no longer supported.
- PHP 7.4 is no longer supported.