### PR TITLE
Adjust asset paths now the default build tool is Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Deployments are triggered by committing to Git and pushing to GitHub.
 
 - Create a site in your [Netlify](https://netlify.com) account
 - Link the site to your desired GitHub repository
-- Add build command `php please ssg:generate` (if you need to compile css/js, be sure to add that command too and execute it before generating the static site folder. e.g. `npm install && npm run prod && php please ssg:generate`).
+- Add build command `php please ssg:generate` (if you need to compile css/js, be sure to add that command too and execute it before generating the static site folder. e.g. `npm install && npm run build && php please ssg:generate`).
 - Set publish directory `storage/app/static`
 
 After your site has an APP_URL...

--- a/config/ssg.php
+++ b/config/ssg.php
@@ -39,13 +39,13 @@ return [
     */
 
     'copy' => [
-        public_path('css') => 'css',
-        public_path('js') => 'js',
+        public_path('build') => 'build',
+        public_path('assets') => 'assets',
     ],
 
     'symlinks' => [
-        // public_path('css') => 'css',
-        // public_path('js') => 'js',
+//         public_path('build') => 'build',
+//         public_path('assets') => 'assets',
     ],
 
     /*

--- a/config/ssg.php
+++ b/config/ssg.php
@@ -40,12 +40,10 @@ return [
 
     'copy' => [
         public_path('build') => 'build',
-        public_path('assets') => 'assets',
     ],
 
     'symlinks' => [
 //         public_path('build') => 'build',
-//         public_path('assets') => 'assets',
     ],
 
     /*

--- a/config/ssg.php
+++ b/config/ssg.php
@@ -43,7 +43,7 @@ return [
     ],
 
     'symlinks' => [
-//         public_path('build') => 'build',
+        // public_path('build') => 'build',
     ],
 
     /*


### PR DESCRIPTION
This pull request adjusts some of the default configuration options & documentation now that the default build tool in Statamic is Vite, rather than Laravel Mix.