### PR TITLE
Bugfix/remove shuffle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor
 /composer.lock
+.DS_Store
+/.idea

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -239,7 +239,7 @@ class Generator
                 }
 
                 return in_array($page->url(), $this->config['exclude']);
-            })->shuffle();
+            });
     }
 
     protected function makeContentGenerationClosures($pages, $request)


### PR DESCRIPTION
The shuffle function seems to cause index pages of paginated collections to randomly take the view of one of the later pages in the resultset.

It probably needs further digging to understand why the wrong page is being substituted, but simply removing the shuffle seems to solve it for now.