### PR TITLE
Add simple license check

### DIFF
--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -59,7 +59,7 @@ class StaticSiteGenerate extends Command
             $this->error('Statamic Pro is enabled but no site key was found.');
             $this->warn('Please set a valid site key in your .env file.');
 
-            if (! $this->confirm('Do you wish to continue with the ssg:generate command?', true)) {
+            if (! $this->confirm('Do you wish to continue with the ssg:generate command?', $this->option('no-interaction'))) {
                 $this->line('Static site generation canceled.');
 
                 return 0;

--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -63,7 +63,7 @@ class StaticSiteGenerate extends Command
                 $this->line('Static site generation canceled.');
 
                 return 0;
-            };
+            }
         }
 
         if (! $workers = $this->option('workers')) {

--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -56,10 +56,10 @@ class StaticSiteGenerate extends Command
         Partyline::bind($this);
 
         if (config('statamic.editions.pro') && ! config('statamic.system.license_key')) {
-            $this->error('Statamic Pro is enabled but no site key was found.');
-            $this->warn('Please set a valid site key in your .env file.');
+            $this->error('Statamic Pro is enabled but no site license was found.');
+            $this->warn('Please set a valid Statamic License Key in your .env file.');
 
-            if (! $this->confirm('Do you wish to continue with the ssg:generate command?', $this->option('no-interaction'))) {
+            if (! $this->confirm('By continuing you agree that this build is for testing purposes only. Do you wish to continue?', $this->option('no-interaction'))) {
                 $this->line('Static site generation canceled.');
 
                 return 0;

--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -58,8 +58,9 @@ class StaticSiteGenerate extends Command
         if (config('statamic.editions.pro') && ! config('statamic.system.license_key')) {
             $this->error('Statamic Pro is enabled but no site license was found.');
             $this->warn('Please set a valid Statamic License Key in your .env file.');
+            $confirmationText = 'By continuing you agree that this build is for testing purposes only. Do you wish to continue?';
 
-            if (! $this->confirm('By continuing you agree that this build is for testing purposes only. Do you wish to continue?', $this->option('no-interaction'))) {
+            if (! $this->option('no-interaction') && ! $this->confirm($confirmationText)) {
                 $this->line('Static site generation canceled.');
 
                 return 0;

--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -55,6 +55,17 @@ class StaticSiteGenerate extends Command
     {
         Partyline::bind($this);
 
+        if (config('statamic.editions.pro') && ! config('statamic.system.license_key')) {
+            $this->error('Statamic Pro is enabled but no site key was found.');
+            $this->warn('Please set a valid site key in your .env file.');
+
+            if (! $this->confirm('Do you wish to continue with the ssg:generate command?', true)) {
+                $this->line('Static site generation canceled.');
+
+                return 0;
+            };
+        }
+
         if (! $workers = $this->option('workers')) {
             $this->comment('You may be able to speed up site generation significantly by installing spatie/fork and using multiple workers (requires PHP 8+).');
         }

--- a/tests/Concerns/RunsGeneratorCommand.php
+++ b/tests/Concerns/RunsGeneratorCommand.php
@@ -26,6 +26,8 @@ trait RunsGeneratorCommand
     {
         $this->assertFalse($this->files->exists($this->destination));
 
+        $options['--no-interaction'] ??= true;
+
         $this
             ->artisan('statamic:ssg:generate', $options)
             ->doesntExpectOutputToContain('pages not generated');


### PR DESCRIPTION
Adds a simple check to look for a site key when Statamic Pro is enabled before running the actual `ssg:generate` command.
![CleanShot 2023-08-11 at 11 41 52](https://github.com/statamic/ssg/assets/3824203/e65f0d6f-0a6f-496a-a0ed-684b596f0bc9)
