### PR TITLE
Add `ssg.running` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ You may configure a custom routing style in `config/statamic/ssg.php`:
 'pagination_route' => '{url}/{page_name}/{page_number}',
 ``` 
 
+## Views
+
+You can tell if the SSG was running from your templates by using the following check.
+
+This is antlers, but the same principle will work for any conditional checking the `statamic.ssg.running` config key:
+
+```
+{{ if ! config:statamic:ssg:running }}
+    <meta name="csrf-token" content="{{ csrf_token }}">
+{{ /if }}
+```
 
 ## Post-generation callback
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,24 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="tests">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
-	<env name="APP_URL" value="http://cool-runnings.com" />
-	<env name="APP_KEY" value="base64:QeU8nSJFKtBB3Y9SdxH0U4xH/1rsFd4zNfOLTeK/DUw=" />
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="tests">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="QUEUE_DRIVER" value="sync"/>
+    <env name="APP_URL" value="http://cool-runnings.com"/>
+    <env name="APP_KEY" value="base64:QeU8nSJFKtBB3Y9SdxH0U4xH/1rsFd4zNfOLTeK/DUw="/>
+  </php>
 </phpunit>

--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -55,6 +55,8 @@ class StaticSiteGenerate extends Command
     {
         Partyline::bind($this);
 
+        config(['statamic.ssg.running' => true]);
+
         if (config('statamic.editions.pro') && ! config('statamic.system.license_key')) {
             $this->error('Statamic Pro is enabled but no site license was found.');
             $this->warn('Please set a valid Statamic License Key in your .env file.');

--- a/tests/Concerns/RunsGeneratorCommand.php
+++ b/tests/Concerns/RunsGeneratorCommand.php
@@ -33,6 +33,8 @@ trait RunsGeneratorCommand
             ->doesntExpectOutputToContain('pages not generated');
 
         $this->assertTrue($this->files->exists($this->destination));
+        
+        $this->assertTrue(app('config')->get('statamic.ssg.running'));
 
         return $this->getGeneratedFilesAtPath($this->destination);
     }

--- a/tests/Concerns/RunsGeneratorCommand.php
+++ b/tests/Concerns/RunsGeneratorCommand.php
@@ -33,7 +33,7 @@ trait RunsGeneratorCommand
             ->doesntExpectOutputToContain('pages not generated');
 
         $this->assertTrue($this->files->exists($this->destination));
-        
+
         $this->assertTrue(app('config')->get('statamic.ssg.running'));
 
         return $this->getGeneratedFilesAtPath($this->destination);


### PR DESCRIPTION
### Use-case
I have a site that uses the SSG but also runs fully dynamically elsewhere. Having this flag enables me to cut out/replace parts of templates that are 'too' dynamic with something more predictable for the SSG-generated version without having to completely remove chunks of template manually.

The case given in the readme is the most pressing example, but I'm sure there will be others.

### Why a dynamic config key?
A static one will be present all of the time, so always `true` or always `false`. It could be added to the file, but that seems a bit redundant - no one should ever tamper with it.

### Why not an env variable or some other variable?
Mainly down to antlers support - I wanted something I could access easily in my templates without much fuss and without polluting the global namespace with another variable.

The [`config`](https://statamic.dev/variables/config) array is readily accessible for this - and I checked: this still works even after running `php artisan config:cache`.