### PR TITLE
Optimize performance when gathering content pages

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -15,12 +15,14 @@ class Page
     protected $content;
     protected $paginationPageName;
     protected $paginationCurrentPage;
+    protected $url;
 
     public function __construct(Filesystem $files, array $config, $content)
     {
         $this->files = $files;
         $this->config = $config;
         $this->content = $content;
+        $this->url = null;
     }
 
     public function content()
@@ -115,6 +117,10 @@ class Page
 
     public function url()
     {
+        if ($this->url !== null) {
+            return $this->url;
+        }
+
         $url = $this->content->urlWithoutRedirect();
 
         if ($this->paginationCurrentPage) {
@@ -125,7 +131,9 @@ class Page
             );
         }
 
-        return $url;
+        $this->url = $url;
+
+        return $this->url;
     }
 
     public function site()


### PR DESCRIPTION
When you have a lot of content, Statamic allows us to optimize ssg build time by using `spatie/fork` dependency to have concurrent builds. However, the step "Gathering content files" still takes a long time, because it is not been executed concurrently. In my case this took around 30 seconds for ~5k entries.

Some background, why this takes so long on larger sites:
Everytime [you fetch the `url()` from an Entry](https://github.com/statamic/ssg/blob/master/src/Generator.php#L258C21-L259), it runs the [`build()` function from Statamic\Routing\UrlBuilder](https://github.com/o1y/statamic-cms/blob/ea7d3df6d6fa203a9e59ae0ed859153077106874/src/Routing/UrlBuilder.php#L52), which is augmenting _all_ fields just to build the url. If an entry has a lot of content fields, this could take a while. Some entries took up to 50ms for me to just return the url.

The best approach to speed up the UrlBuilder here would be to only augmenting those fields, which are required for the URL (possibly by parsing the params from the Collection url string first). That requires a bit more effort in the `statamic/cms` project.

I made it a bit easier by running the generation of all `StaticSite\Page` objects in parallel via `spatie/fork`. That speeds up the "Gathering Content Pages" part for me by 83% (from 30s to only 5s). However, that depends on how much cores you have on your machine. 🚀