### PR TITLE
Statamic 5: Update "Installation" section to mention `install:ssg` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,13 @@
 
 ## Installation
 
-Install the package using Composer:
+You can install the Static Site Generator package with the following command:
 
 ```
-composer require statamic/ssg
+php please install:ssg
 ```
 
-If you want or need to customize the way the site is generated, you can do so by publishing and modifying the config file with the following command:
-
-```
-php artisan vendor:publish --provider="Statamic\StaticSite\ServiceProvider"
-```
-
-The config file will be in `config/statamic/ssg.php`. This is optional and you can do it anytime.
+The command will install the `statamic/ssg` package via Composer, optionally publish the configuration file and prompt you if you wish to install the `spatie/fork` package for running [multiple workers](#multiple-workers).
 
 
 ## Usage
@@ -28,6 +22,7 @@ php please ssg:generate
 ```
 
 Your site will be generated into a directory which you can deploy however you like. See [Deployment Examples](#deployment-examples) below for inspiration.
+
 
 ### Multiple Workers
 


### PR DESCRIPTION
This pull request updates the "Installation" section of the addon's `README.md` to mention the new `install:ssg` command introduced by statamic/cms#9622.

This PR should be merged whenever Statamic 5 compatibility is released for this addon.