### PR TITLE
Request uri falls back to slash when page is missing

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -48,7 +48,7 @@ class Request extends \Illuminate\Http\Request
 
     public function getPathInfo(): string
     {
-        return $this->page->url();
+        return $this->page?->url() ?? '/';
     }
 
     public function path()


### PR DESCRIPTION
Fixes #134 

We fake the request, then have a "gather content" step, and then we loop through everything later to generate them. Only in the later point do we set the page on our faked request.

Michael was running into the issue because he is trying to get the request url during the "gather content" step when there is no page defined yet.

This PR makes the path fall back to `/` when there is no page. This is consistent with how Symfony's request works. If you do `request()->path()` in a console command, you'd get `/`.
