### PR TITLE
Flush Blink when Page has been generated

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Arr;
 use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use Statamic\Contracts\Imaging\UrlBuilder;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Glide;
@@ -301,6 +302,8 @@ class Generator
 
                         $warnings[] = $generated->consoleMessage();
                     }
+
+                    Blink::flush();
                 }
 
                 return compact('count', 'warnings', 'errors');


### PR DESCRIPTION
Fixes #171 and fixes #170

It may happen that cached values of a request with Blink are used in further requests, which are handled on the same php process, leading to incorrect results. To prevent this from happening, Blink is flushed after every request.