### PR TITLE
Optimize performance when gathering content pages

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
 use League\Flysystem\Filesystem as Flysystem;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use Statamic\Contracts\Imaging\UrlBuilder;
@@ -244,16 +245,37 @@ class Generator
 
     protected function gatherAllPages()
     {
-        return collect()
+        $pages = collect()
             ->merge($this->routes())
             ->merge($this->urls())
             ->merge($this->entries())
             ->merge($this->terms())
             ->merge($this->scopedTerms())
-            ->values()
-            ->unique
-            ->url()
-            ->reject(fn ($page) => $this->shouldRejectPage($page));
+            ->values();
+
+        $closures = $this->makeCachePagesClosures($pages);
+
+        $results = $this->tasks->run(...$closures);
+
+        return collect($results)->flatMap(function ($key) {
+            return Cache::pull($key);
+        })->unique->url();
+    }
+
+    protected function makeCachePagesClosures($pages)
+    {
+        return $pages->split($this->workers)->map(function ($pages, $key) {
+            return function () use ($pages, $key) {
+                $cacheKey = "ssg::pages::{$key}";
+
+                $pages = $pages
+                    ->reject(fn ($page) => $this->shouldRejectPage($page));
+
+                Cache::put($cacheKey, $pages);
+
+                return $cacheKey;
+            };
+        });
     }
 
     protected function makeContentGenerationClosures($pages, $request)


### PR DESCRIPTION
Reimplement #154. Content gathering could take a long time for large Statamic sites. This commit makes these calls concurrent if `spatie/fork` is available.

In this implementation, URLs will no longer be cached in SSG because Statamic 5 already has an optimization for it.