### PR TITLE
allow suppression of generating messages

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -264,6 +264,7 @@ class Generator
                 $count = 0;
                 $warnings = [];
                 $errors = [];
+                $verbose = env('SSG_VERBOSE', true);
 
                 foreach ($pages as $page) {
                     // There is no getter method, so use reflection.
@@ -279,7 +280,9 @@ class Generator
 
                     $request->setPage($page);
 
-                    Partyline::line("\x1B[1A\x1B[2KGenerating ".$page->url());
+                    if ($verbose) {
+                        Partyline::line("\x1B[1A\x1B[2KGenerating ".$page->url());
+                    }
 
                     try {
                         $generated = $page->generate($request);


### PR DESCRIPTION
Allow SSG to be a little less verbose by checking an `SSG_VERBOSE` env variable before outputting the individual file names being generated.