### PR TITLE
Add `verbose` option

### DIFF
--- a/config/ssg.php
+++ b/config/ssg.php
@@ -115,4 +115,18 @@ return [
 
     'failures' => false, // 'errors' or 'warnings'
 
+    /*
+    |--------------------------------------------------------------------------
+    | Verbosity
+    |--------------------------------------------------------------------------
+    |
+    | By default SSG will print out a lot of information about 
+    | what it is doing, including a line for every file it outputs.
+    |
+    | This option allows you to choose to get a little less information.
+    |
+    */
+
+    'verbose' => true,
+
 ];

--- a/config/ssg.php
+++ b/config/ssg.php
@@ -120,7 +120,7 @@ return [
     | Verbosity
     |--------------------------------------------------------------------------
     |
-    | By default SSG will print out a lot of information about 
+    | By default SSG will print out a lot of information about
     | what it is doing, including a line for every file it outputs.
     |
     | This option allows you to choose to get a little less information.

--- a/config/ssg.php
+++ b/config/ssg.php
@@ -120,10 +120,8 @@ return [
     | Verbosity
     |--------------------------------------------------------------------------
     |
-    | By default SSG will print out a lot of information about
-    | what it is doing, including a line for every file it outputs.
-    |
-    | This option allows you to choose to get a little less information.
+    | When enabled, the SSG will print a line for every page it generates.
+    | Useful for debugging or keeping track of the command's progress.
     |
     */
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -282,8 +282,8 @@ class Generator
                     $request->setPage($page);
 
                     if ($verbose) {
-                        Partyline::line("\x1B[1A\x1B[2KGenerating " . $page->url());
-                    };
+                        Partyline::line("\x1B[1A\x1B[2KGenerating ".$page->url());
+                    }
 
                     try {
                         $generated = $page->generate($request);

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -266,6 +266,7 @@ class Generator
                 $count = 0;
                 $warnings = [];
                 $errors = [];
+                $verbose = config('statamic.ssg.verbose');
 
                 foreach ($pages as $page) {
                     $oldCarbonFormat = $this->getToStringFormat();
@@ -280,7 +281,9 @@ class Generator
 
                     $request->setPage($page);
 
-                    Partyline::line("\x1B[1A\x1B[2KGenerating ".$page->url());
+                    if ($verbose) {
+                        Partyline::line("\x1B[1A\x1B[2KGenerating " . $page->url());
+                    };
 
                     try {
                         $generated = $page->generate($request);


### PR DESCRIPTION
This patch adds a `verbose` option to the config. If changed to `false` this will prevent the creation of a new line for every file encountered.

Closes #188