### PR TITLE
[4.x] Improved Timezone Handling

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -272,7 +272,7 @@ class Generator
 
                     if ($this->shouldSetCarbonFormat($page)) {
                         Date::setToStringFormat(function (Carbon $date) {
-                            return $date->setTimezone(config('statamic.system.display_timezone'))->format(Statamic::dateFormat());
+                            return $date->setTimezone(Statamic::displayTimezone())->format(Statamic::dateFormat());
                         });
                     }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -271,7 +271,9 @@ class Generator
                     $oldCarbonFormat = $this->getToStringFormat();
 
                     if ($this->shouldSetCarbonFormat($page)) {
-                        Carbon::setToStringFormat(Statamic::dateFormat());
+                        Date::setToStringFormat(function (Carbon $date) {
+                            return $date->setTimezone(config('statamic.system.display_timezone'))->format(Statamic::dateFormat());
+                        });
                     }
 
                     $this->updateCurrentSite($page->site());
@@ -489,7 +491,7 @@ class Generator
      *
      * @throws \ReflectionException
      */
-    protected function getToStringFormat(): ?string
+    protected function getToStringFormat(): string|\Closure|null
     {
         $reflection = new ReflectionClass($date = Date::now());
 


### PR DESCRIPTION
This pull request ensures that the new `display_timezone` config option is taken into account when the SSG sets Carbon's `toStringFormat` setting.

Goes alongside https://github.com/statamic/cms/pull/11409