### PR TITLE
[4.x] Remove `toStringFormat` handling for Carbon 2

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -493,15 +493,6 @@ class Generator
     {
         $reflection = new ReflectionClass($date = Date::now());
 
-        // Carbon 2.x
-        if ($reflection->hasProperty('toStringFormat')) {
-            $format = $reflection->getProperty('toStringFormat');
-            $format->setAccessible(true);
-
-            return $format->getValue();
-        }
-
-        // Carbon 3.x
         $factory = $reflection->getMethod('getFactory');
         $factory->setAccessible(true);
 


### PR DESCRIPTION
This pull request removes the `toStringFormat` handling for Carbon 2, which is no longer supported in Statamic 6. 

Related: https://github.com/statamic/cms/pull/11500