### PR TITLE
Allow enforcement of trailing slashes on urls and links

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,26 +12,19 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: [11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
           - os: windows-latest
             php: 8.3
-            laravel: 10.*
+            laravel: 11.*
             stability: prefer-stable
           - os: windows-latest
-            php: 8.3
-            laravel: 11.*
-            stability: prefer-stable
-        exclude:
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.1
+            php: 8.4
             laravel: 12.*
-          - php: 8.4
-            laravel: 10.*
+            stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
         "statamic/cms": "dev-master"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",
-        "phpunit/phpunit": "^10.5.35 || ^11.0"
+        "orchestra/testbench": "^9.6.1 || ^10.0",
+        "phpunit/phpunit": "^11.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "statamic/cms": "dev-master"
+        "statamic/cms": "dev-url-trailing-slashes as 6.0"
     },
     "require-dev": {
         "orchestra/testbench": "^9.6.1 || ^10.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "statamic/cms": "^5.41"
+        "statamic/cms": "dev-master"
     },
     "require-dev": {
         "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0",

--- a/config/ssg.php
+++ b/config/ssg.php
@@ -82,8 +82,6 @@ return [
     | hosts expect trailing slashes on URLs for things like SEO sitemaps
     | and RSS feeds in order to comply with the server configuration.
     |
-    | NOTE: This is an experimental feature, and requires Statamic 6+!
-    |
     */
 
     'enforce_trailing_slashes' => false,

--- a/config/ssg.php
+++ b/config/ssg.php
@@ -75,6 +75,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Trailing Slashes
+    |--------------------------------------------------------------------------
+    |
+    | Enable to enforce trailing slashes on generated URLs. Some static site
+    | hosts expect trailing slashes on URLs for things like SEO sitemaps
+    | and RSS feeds in order to comply with the server configuration.
+    |
+    | NOTE: This is an experimental feature, and requires Statamic 6+!
+    |
+    */
+
+    'enforce_trailing_slashes' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Pagination Route
     |--------------------------------------------------------------------------
     |

--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -4,6 +4,7 @@ namespace Statamic\StaticSite\Commands;
 
 use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
+use Statamic\Facades\URL;
 use Statamic\StaticSite\GenerationFailedException;
 use Statamic\StaticSite\Generator;
 use Wilderborn\Partyline\Facade as Partyline;
@@ -53,6 +54,10 @@ class StaticSiteGenerate extends Command
      */
     public function handle()
     {
+        if (config('statamic.ssg.enforce_trailing_slashes')) {
+            URL::enforceTrailingSlashes();
+        }
+
         Partyline::bind($this);
 
         if (config('statamic.editions.pro') && ! config('statamic.system.license_key')) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -463,7 +463,7 @@ class Generator
 
     protected function makeAbsoluteUrl($url)
     {
-        return URL::tidy(Str::start($url, $this->config['base_url'].'/'));
+        return URL::assemble($this->config['base_url'], $url);
     }
 
     protected function shouldRejectPage($page, $outputError = false)

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -271,7 +271,9 @@ class Generator
                     $oldCarbonFormat = $this->getToStringFormat();
 
                     if ($this->shouldSetCarbonFormat($page)) {
-                        Carbon::setToStringFormat(Statamic::dateFormat());
+                        Date::setToStringFormat(function (Carbon $date) {
+                            return $date->setTimezone(Statamic::displayTimezone())->format(Statamic::dateFormat());
+                        });
                     }
 
                     $this->updateCurrentSite($page->site());
@@ -489,7 +491,7 @@ class Generator
      *
      * @throws \ReflectionException
      */
-    protected function getToStringFormat(): ?string
+    protected function getToStringFormat(): string|\Closure|null
     {
         $reflection = new ReflectionClass($date = Date::now());
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -493,15 +493,6 @@ class Generator
     {
         $reflection = new ReflectionClass($date = Date::now());
 
-        // Carbon 2.x
-        if ($reflection->hasProperty('toStringFormat')) {
-            $format = $reflection->getProperty('toStringFormat');
-            $format->setAccessible(true);
-
-            return $format->getValue();
-        }
-
-        // Carbon 3.x
         $factory = $reflection->getMethod('getFactory');
         $factory->setAccessible(true);
 

--- a/src/Page.php
+++ b/src/Page.php
@@ -7,6 +7,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\RedirectResponse;
 use Statamic\Facades\Blink;
+use Statamic\Facades\URL;
 
 class Page
 {
@@ -135,7 +136,7 @@ class Page
 
     public function is404()
     {
-        return $this->url() === '/404';
+        return $this->url() === URL::tidy('/404');
     }
 
     public function setPaginationCurrentPage($currentPage)

--- a/src/Route.php
+++ b/src/Route.php
@@ -41,7 +41,7 @@ class Route
         $kernel->terminate($request, $response);
 
         if ($e = $response->exception) {
-            if ($response->status() === 404 && $this->url() === '/404') {
+            if ($response->status() === 404 && $this->url() === URL::tidy('/404')) {
                 return $response;
             }
 

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -410,4 +410,16 @@ EOT
         $page3 = $files['articles/page/3/index.html'];
         $this->assertStringContainsString('Prev Link: /articles/page/2/', $page3);
     }
+
+    /** @test */
+    public function it_still_generates_404_when_trailing_slashes_config_is_enabled()
+    {
+        Config::set('statamic.ssg.enforce_trailing_slashes', true);
+
+        $files = $this->generate();
+
+        $this->assertContains('404.html', array_keys($files));
+
+        $this->assertStringContainsString('<h1>404!</h1>', $files['404.html']);
+    }
 }

--- a/tests/Localized/GenerateTest.php
+++ b/tests/Localized/GenerateTest.php
@@ -361,4 +361,16 @@ EOT
         $frPage2 = $files['fr/le-articles/page/2/index.html'];
         $this->assertStringContainsString('Prev Link: /fr/le-articles/page/1/', $frPage2);
     }
+
+    /** @test */
+    public function it_still_generates_404_when_trailing_slashes_config_is_enabled()
+    {
+        Config::set('statamic.ssg.enforce_trailing_slashes', true);
+
+        $files = $this->generate();
+
+        $this->assertContains('404.html', array_keys($files));
+
+        $this->assertStringContainsString('<h1>404!</h1>', $files['404.html']);
+    }
 }

--- a/tests/Localized/GenerateTest.php
+++ b/tests/Localized/GenerateTest.php
@@ -5,6 +5,7 @@ namespace Tests\Localized;
 use Illuminate\Filesystem\Filesystem;
 use Statamic\Facades\Config;
 use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 use Tests\Concerns\RunsGeneratorCommand;
 use Tests\TestCase;
 
@@ -38,6 +39,14 @@ class GenerateTest extends TestCase
                 'url' => '/it/',
             ],
         ]);
+    }
+
+    protected function tearDown(): void
+    {
+        URL::enforceTrailingSlashes(false);
+        URL::clearUrlCache();
+
+        parent::tearDown();
     }
 
     /** @test */
@@ -300,5 +309,56 @@ EOT
         $this->assertStringContainsString('Current Page: 2', $index);
         $this->assertStringContainsString('Total Pages: 2', $index);
         $this->assertStringContainsString('Prev Link: /fr/le-articles/page/1', $index);
+    }
+
+    /** @test */
+    public function it_enforces_trailing_slashes_when_config_enabled()
+    {
+        Config::set('statamic.ssg.enforce_trailing_slashes', true);
+
+        $files = $this->generate();
+
+        $index = $files['articles/index.html'];
+        $this->assertStringContainsString('<a href="http://cool-runnings.com/articles/one/">One</a>', $index);
+        $this->assertStringContainsString('<a href="http://cool-runnings.com/articles/two/">Two</a>', $index);
+        $this->assertStringContainsString('<a href="http://cool-runnings.com/articles/three/">Three</a>', $index);
+
+        $frIndex = $files['fr/le-articles/index.html'];
+        $this->assertStringContainsString('<a href="http://cool-runnings.com/fr/le-articles/le-one/">Le One</a>', $frIndex);
+        $this->assertStringContainsString('<a href="http://cool-runnings.com/fr/le-articles/le-two/">Le Two</a>', $frIndex);
+        $this->assertStringContainsString('<a href="http://cool-runnings.com/fr/le-articles/le-three/">Le Three</a>', $frIndex);
+    }
+
+    /** @test */
+    public function it_enforces_trailing_slashes_on_localized_paginated_urls_when_config_enabled()
+    {
+        Config::set('statamic.ssg.enforce_trailing_slashes', true);
+
+        $this->files->put(resource_path('views/articles/index.antlers.html'), <<<'EOT'
+{{ collection:articles sort="date:asc" paginate="3" as="articles" }}
+    {{ articles }}
+        <a href="{{ permalink }}">{{ title }}</a>
+    {{ /articles }}
+
+    {{ paginate }}
+        Current Page: {{ current_page }}
+        Total Pages: {{ total_pages }}
+        Prev Link: {{ prev_page }}
+        Next Link: {{ next_page }}
+    {{ /paginate }}
+{{ /collection:articles }}
+EOT
+        );
+
+        $files = $this->generate();
+
+        $index = $files['articles/index.html'];
+        $this->assertStringContainsString('Next Link: /articles/page/2/', $index);
+
+        $frIndex = $files['fr/le-articles/index.html'];
+        $this->assertStringContainsString('Next Link: /fr/le-articles/page/2/', $frIndex);
+
+        $frPage2 = $files['fr/le-articles/page/2/index.html'];
+        $this->assertStringContainsString('Prev Link: /fr/le-articles/page/1/', $frPage2);
     }
 }


### PR DESCRIPTION
This PR adds config to enforce trailing slashes on urls and links during SSG generation. This is useful for things like SEO sitemap, RSS feeds, etc. on server hosts that bias towards trailing slashes (ie. Netlify [expects trailing slashes for SEO](https://github.com/statamic/seo-pro/issues/387#issuecomment-2917533542)).

## Todo

- [x] Add opt-in config
- [x] Wire up config to enforce trailing slashes on `ssg:generate` only
  - We don't want this always running in the service provider!
- [x] Flesh out test coverage

References https://github.com/statamic/ssg/issues/65
References https://github.com/statamic/cms/pull/11840