### PR TITLE
Fix race-condition with multiple workers

### DIFF
--- a/src/Page.php
+++ b/src/Page.php
@@ -63,9 +63,7 @@ class Page
 
         $html = $response->getContent();
 
-        if (! $this->files->exists($this->directory())) {
-            $this->files->makeDirectory($this->directory(), 0755, true);
-        }
+        $this->files->makeDirectory($this->directory(), 0755, true, true);
 
         $this->files->put($this->path(), $html);
 

--- a/src/Page.php
+++ b/src/Page.php
@@ -63,7 +63,7 @@ class Page
 
         $html = $response->getContent();
 
-        $this->files->makeDirectory($this->directory(), 0755, true, true);
+        $this->files->makeDirectory($this->directory(), recursive: true, force: true);
 
         $this->files->put($this->path(), $html);
 


### PR DESCRIPTION
When running ssg with multiple workers, different forked processes might check for an existing folder and attempt to create it "simultaneously", which will cause makeDirectory to fail (folder already exists) and ssg to abort.

The fix uses 'force' to ignore errors on makeDirectory(). If it fails with errors other than 'folder already exists', then the following put() should also fail, meaning, it won't go unnoticed.