### PR TITLE
Multiple afters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "statamic/cms": "dev-master"
+        "statamic/cms": "^5.41"
     },
     "require-dev": {
         "orchestra/testbench": "^9.6.1 || ^10.0",

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -73,13 +73,15 @@ class Generator
         return $this;
     }
 
-    public function after($after, $id = 'unidentified') {
+    public function after($after, $id = 'unidentified') 
+    {
         $this->after[$id] = $after;
 
         return $this;
     }
     
-    public function skipAfter( string $id ) {
+    public function skipAfter( string $id ) 
+    {
         $this->skipAfter[] = $id;
     }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -113,17 +113,17 @@ class Generator
             ->copyFiles()
             ->outputSummary();
 
-            if ( count($this->after) > 0 ) {
-                foreach ($this->after as $id => $after) {
-                    if (in_array($id, $this->skipAfter)) {
-                        Partyline::line("<comment>Skipping $id after function...</comment>");
-                        continue;
-                    }
-                    Partyline::line("<info>Calling $id after function...</info>");
-                    call_user_func($after);
+        if ( count($this->after) > 0 ) {
+            foreach ($this->after as $id => $after) {
+                if (in_array($id, $this->skipAfter)) {
+                    Partyline::line("<comment>Skipping $id after function...</comment>");
+                    continue;
                 }
+                Partyline::line("<info>Calling $id after function...</info>");
+                call_user_func($after);
             }
         }
+    }
 
     public function bindGlide()
     {


### PR DESCRIPTION
This implements a method of allowing more than one after callback, as requested in #182.

It adds an option `$id` parameter to the `SSG::after` method that defaults to `"unidentified"`. This means that all existing calls to  `SSG::after` will work as they always have, overwriting one another. However, if one supplies an identifier string, then the callback function will be added to an array of callback functions instead of overwriting previous after callbacks.

One can also specify identifiers that should be skipped using the new `SSG::skipAfter` method. This allows you to explicitly prevent after callbacks from other parties from being run (for example, if you supply similar functionality yourself or you have found that their callback is incompatible with your use case).

Finally, it uses the identifiers to inform the user which after callbacks are being run or skipped.

Note the reversion in `composer.json` is probably not necessary, but was required to get the addon installed on my system.  