### PR TITLE
Improve output of `ssg:generate` command

### DIFF
--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -8,6 +8,7 @@ use Statamic\Facades\URL;
 use Statamic\StaticSite\GenerationFailedException;
 use Statamic\StaticSite\Generator;
 use Wilderborn\Partyline\Facade as Partyline;
+use function Laravel\Prompts\confirm;
 
 class StaticSiteGenerate extends Command
 {
@@ -61,19 +62,19 @@ class StaticSiteGenerate extends Command
         Partyline::bind($this);
 
         if (config('statamic.editions.pro') && ! config('statamic.system.license_key')) {
-            $this->error('Statamic Pro is enabled but no site license was found.');
-            $this->warn('Please set a valid Statamic License Key in your .env file.');
+            $this->components->error('Statamic Pro is enabled but no site license was found.');
+            $this->components->warn('Please set a valid Statamic License Key in your .env file.');
             $confirmationText = 'By continuing you agree that this build is for testing purposes only. Do you wish to continue?';
 
-            if (! $this->option('no-interaction') && ! $this->confirm($confirmationText)) {
-                $this->line('Static site generation canceled.');
+            if (! $this->option('no-interaction') && ! confirm($confirmationText)) {
+                $this->components->error('Static site generation canceled.');
 
                 return 0;
             }
         }
 
         if (! $workers = $this->option('workers')) {
-            $this->comment('You may be able to speed up site generation significantly by installing spatie/fork and using multiple workers (requires PHP 8+).');
+             $this->components->info('You may be able to speed up site generation significantly by installing spatie/fork and using multiple workers.');
         }
 
         try {
@@ -82,8 +83,8 @@ class StaticSiteGenerate extends Command
                 ->disableClear($this->option('disable-clear') ?? false)
                 ->generate($this->argument('urls') ?: '*');
         } catch (GenerationFailedException $e) {
-            $this->line($e->getConsoleMessage());
-            $this->error('Static site generation failed.');
+            $this->components->error($e->getConsoleMessage());
+            $this->components->error('Static site generation failed.');
 
             return 1;
         }

--- a/src/Commands/StaticSiteGenerate.php
+++ b/src/Commands/StaticSiteGenerate.php
@@ -8,6 +8,7 @@ use Statamic\Facades\URL;
 use Statamic\StaticSite\GenerationFailedException;
 use Statamic\StaticSite\Generator;
 use Wilderborn\Partyline\Facade as Partyline;
+
 use function Laravel\Prompts\confirm;
 
 class StaticSiteGenerate extends Command
@@ -74,7 +75,7 @@ class StaticSiteGenerate extends Command
         }
 
         if (! $workers = $this->option('workers')) {
-             $this->components->info('You may be able to speed up site generation significantly by installing spatie/fork and using multiple workers.');
+            $this->components->info('You may be able to speed up site generation significantly by installing spatie/fork and using multiple workers.');
         }
 
         try {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -196,7 +196,7 @@ class Generator
             $pages = $pages->shuffle();
         }
 
-        Partyline::line("Generating {$pages->count()} content files...");
+        Partyline::outputComponents()->info("Generating {$pages->count()} content files...");
 
         $closures = $this->makeContentGenerationClosures($pages, $request);
 
@@ -242,7 +242,6 @@ class Generator
             'Gathering content to be generated...',
         );
 
-        // todo
         Partyline::outputComponents()->info('Gathered content to be generated');
 
         return $pages;
@@ -285,8 +284,7 @@ class Generator
 
                     $request->setPage($page);
 
-//                    Partyline::outputComponents()->twoColumnDetail($page->url(), '<info>Generating...</info>');
-                    Partyline::line("\x1B[1A\x1B[2KGenerating ".$page->url());
+                    Partyline::line("  Generating ".$page->url());
 
                     try {
                         $generated = $page->generate($request);
@@ -324,9 +322,11 @@ class Generator
 
         $successCount = $results['count'] - $results['errors']->count();
 
+        Partyline::newLine();
         Partyline::outputComponents()->success("Generated {$successCount} content files");
 
-        $results['warnings']->merge($results['errors'])->each(fn ($error) => Partyline::line($error));
+        $results['warnings']->each(fn ($warning) => Partyline::outputComponents()->warn($warning));
+        $results['errors']->each(fn ($error) => Partyline::outputComponents()->error($error));
     }
 
     protected function outputSummary()

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -224,10 +224,8 @@ class Generator
 
         return [
             'count' => count($this->earlyTaskErrors) + $results->sum('count'),
-//            'warnings' => $results->flatMap->warnings,
-            'warnings' => 0,
-//            'errors' => collect($this->earlyTaskErrors)->merge($results->flatMap->errors),
-            'errors' => collect(),
+            'warnings' => $results->flatMap->warnings,
+            'errors' => collect($this->earlyTaskErrors)->merge($results->flatMap->errors),
         ];
     }
 
@@ -286,7 +284,7 @@ class Generator
 
                     $request->setPage($page);
 
-                    $this->outputProgress($page->url(), '<fg=blue;options=bold>GENERATING</>');
+                    $this->writeGeneratingLine($page->url());
 
                     try {
                         $generated = $page->generate($request);
@@ -295,8 +293,7 @@ class Generator
                             return $e->consoleMessage();
                         }
 
-                        // Clear line, then output FAILED status with newline
-                        $this->clearLine();
+                        $this->clearCurrentLine();
                         Partyline::outputComponents()->twoColumnDetail($page->url(), '<fg=red;options=bold>FAILED</>');
 
                         $errors[] = $e->consoleMessage();
@@ -314,8 +311,7 @@ class Generator
                         $warnings[] = $generated->consoleMessage();
                     }
 
-                    // Clear line, then output SUCCESS status with newline
-                    $this->clearLine();
+                    $this->clearCurrentLine();
                     Partyline::outputComponents()->twoColumnDetail($page->url(), '<fg=green;options=bold>SUCCESS</>');
 
                     Blink::flush();
@@ -335,8 +331,8 @@ class Generator
         Partyline::newLine();
         Partyline::outputComponents()->success("Generated {$successCount} content files");
 
-//        $results['warnings']->each(fn ($warning) => Partyline::outputComponents()->warn($warning));
-//        $results['errors']->each(fn ($error) => Partyline::outputComponents()->error($error));
+        $results['warnings']->each(fn ($warning) => Partyline::outputComponents()->warn($warning));
+        $results['errors']->each(fn ($error) => Partyline::outputComponents()->error($error));
     }
 
     protected function outputSummary()
@@ -345,13 +341,13 @@ class Generator
 
         $total = $this->taskResults['count'];
 
-//        if ($errors = count($this->taskResults['errors'])) {
-//            Partyline::outputComponents()->warn("{$errors}/{$total} pages not generated");
-//        }
-//
-//        if ($warnings = count($this->taskResults['warnings'])) {
-//            Partyline::outputComponents()->warn("{$warnings}/{$total} pages generated with warnings");
-//        }
+        if ($errors = count($this->taskResults['errors'])) {
+            Partyline::outputComponents()->warn("{$errors}/{$total} pages not generated");
+        }
+
+        if ($warnings = count($this->taskResults['warnings'])) {
+            Partyline::outputComponents()->warn("{$warnings}/{$total} pages generated with warnings");
+        }
     }
 
     protected function entries()
@@ -515,51 +511,23 @@ class Generator
     }
 
     /**
-     * Output a two-column detail line without a trailing newline.
-     * This allows the line to be overwritten later.
+     * Outputs a "Generating" line to the terminal. Very similar output-wise to Laravel's
+     * ->twoColumnDetail() method, but it allows for replacing the line later, for
+     * success/error statuses.
      */
-    protected function outputProgress(string $first, string $second): void
+    private function writeGeneratingLine(string $url): void
     {
-        // Extract the text from color tags
-        preg_match('/<fg=([^;>]+);options=bold>([^<]+)<\/>/', $second, $matches);
-        $color = $matches[1] ?? 'white';
-        $text = $matches[2] ?? $second;
+        $dotsLen = max(1, 150 - strlen($url) - strlen('GENERATING') - 6);
 
-        // ANSI color codes
-        $colors = [
-            'blue' => "\033[34;1m",
-            'green' => "\033[32;1m",
-            'red' => "\033[31;1m",
-            'reset' => "\033[0m",
-            'gray' => "\033[90m",
-        ];
-
-        // Format: "  first .......... STATUS"
-        // The actual visible width calculation
-        $firstLen = strlen($first);
-        $textLen = strlen($text);
-
-        // Calculate dots to match twoColumnDetail width
-        // Subtract a bit more to account for spacing and ensure alignment
-        $dotsLen = max(1, 150 - $firstLen - $textLen - 6);
-
-        $line = sprintf("  %s %s%s%s %s%s%s",
-            $first,
-            $colors['gray'],
-            str_repeat('.', $dotsLen),
-            $colors['reset'],
-            $colors[$color] ?? '',
-            $text,
-            $colors['reset']
+        $line = sprintf("  %s \033[90m%s\033[0m \033[34;1mGENERATING\033[0m",
+            $url,
+            str_repeat('.', $dotsLen)
         );
 
         fwrite(STDERR, $line);
     }
 
-    /**
-     * Clear the current line
-     */
-    protected function clearLine(): void
+    private function clearCurrentLine(): void
     {
         fwrite(STDERR, "\r\x1B[2K");
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -155,10 +155,10 @@ class Generator
             $dest = $this->config['destination'].'/'.$dest;
 
             if ($this->files->exists($dest)) {
-                Partyline::outputComponents()->warn("Symlink not created. $dest already exists.");
+                Partyline::outputComponents()->twoColumnDetail("$source symlinked to $dest", '<fg=blue;options=bold>SKIPPED. SYMLINK ALREADY EXISTS</>');
             } else {
                 $this->files->link($source, $dest);
-                Partyline::outputComponents()->success("$source symlinked to $dest");
+                Partyline::outputComponents()->twoColumnDetail("$source symlinked to $dest", '<fg=green;options=bold>SUCCESS</>');
             }
         }
 
@@ -176,7 +176,7 @@ class Generator
                 $this->files->copyDirectory($source, $dest);
             }
 
-            Partyline::outputComponents()->success("$source copied to $dest");
+            Partyline::outputComponents()->twoColumnDetail("$source copied to $dest", '<fg=green;options=bold>SUCCESS</>');
         }
 
         return $this;

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -284,7 +284,11 @@ class Generator
 
                     $request->setPage($page);
 
-                    $this->writeGeneratingLine($page->url());
+                    // Only write the "Generating" line when using a single worker.
+                    // Otherwise, the output will be messed up.
+                    if ($this->workers === 1) {
+                        $this->writeGeneratingLine($page->url());
+                    }
 
                     try {
                         $generated = $page->generate($request);
@@ -293,7 +297,10 @@ class Generator
                             return $e->consoleMessage();
                         }
 
-                        $this->clearCurrentLine();
+                        if ($this->workers === 1) {
+                            $this->clearCurrentLine();
+                        }
+
                         Partyline::outputComponents()->twoColumnDetail($page->url(), '<fg=red;options=bold>FAILED</>');
 
                         $errors[] = $e->consoleMessage();
@@ -311,7 +318,10 @@ class Generator
                         $warnings[] = $generated->consoleMessage();
                     }
 
-                    $this->clearCurrentLine();
+                    if ($this->workers === 1) {
+                        $this->clearCurrentLine();
+                    }
+
                     Partyline::outputComponents()->twoColumnDetail($page->url(), '<fg=green;options=bold>SUCCESS</>');
 
                     Blink::flush();

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -26,6 +26,7 @@ use Statamic\Imaging\StaticUrlBuilder;
 use Statamic\Statamic;
 use Statamic\Support\Str;
 use Wilderborn\Partyline\Facade as Partyline;
+
 use function Laravel\Prompts\spin;
 
 class Generator


### PR DESCRIPTION
This pull request aims to improve the output of the `ssg:generate` command, bringing it inline with commands in Statamic Core.

## Before

<img width="1604" height="786" alt="CleanShot 2025-10-07 at 13 12 05" src="https://github.com/user-attachments/assets/11e5079b-4d41-4a19-9950-108eaad4e7af" />

## After

<img width="1804" height="1652" alt="CleanShot 2025-10-07 at 13 11 16" src="https://github.com/user-attachments/assets/79357772-32b5-45f0-bfb6-d31b31bd1b19" />

When run on a single worker/process, a "Generating" state will be displayed. The line will eventually be replaced by a success/fail version.

<img width="1519" height="122" alt="CleanShot 2025-10-07 at 13 15 52" src="https://github.com/user-attachments/assets/8d8833d9-4a62-4e59-a5e4-2a8f3449063b" />