### PR TITLE
Supports Laravel 13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,14 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.3, 8.4]
-        laravel: [12.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
           - os: windows-latest
-            php: 8.4
-            laravel: 12.*
+            php: 8.5
+            laravel: 13.*
             stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
         }
     },
     "require": {
-        "statamic/cms": "^6.0.0"
+        "statamic/cms": "^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^10.0",
-        "phpunit/phpunit": "^11.0"
+        "orchestra/testbench": "^10.0 || ^11.0",
+        "phpunit/phpunit": "^11.0 || ^12.0"
     },
     "config": {
         "allow-plugins": {
@@ -37,5 +37,7 @@
     },
     "suggest": {
         "spatie/fork": "Required to generate pages concurrently (^0.0.4)."
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "statamic/cms": "^6.0"
+        "statamic/cms": "^6.5"
     },
     "require-dev": {
         "orchestra/testbench": "^10.0 || ^11.0",


### PR DESCRIPTION
This pull request adds Laravel 13 support to the SSG addon. Laravel 13 is due to be released [Early March](https://x.com/taylorotwell/status/2021555106269831216).

This PR also adds PHP 8.5 to the testing matrix.

Depends on:
* [x] https://github.com/statamic/cms/pull/13870
