### PR TITLE
Migrate PHPUnit metadata to attributes

### DIFF
--- a/tests/ConcurrentTasksTest.php
+++ b/tests/ConcurrentTasksTest.php
@@ -2,12 +2,13 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Spatie\Fork\Fork;
 use Statamic\StaticSite\ConcurrentTasks;
 
 class ConcurrentTasksTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_runs_callbacks()
     {
         $one = function () {

--- a/tests/ConsecutiveTasksTest.php
+++ b/tests/ConsecutiveTasksTest.php
@@ -2,11 +2,12 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\StaticSite\ConsecutiveTasks;
 
 class ConsecutiveTasksTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_runs_callbacks()
     {
         $callbacksRan = 0;

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Config;
 use Statamic\Facades\URL;
 use Tests\Concerns\RunsGeneratorCommand;
@@ -19,7 +20,7 @@ class GenerateTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_pages_for_site_fixture()
     {
         $files = $this->generate();
@@ -68,7 +69,7 @@ class GenerateTest extends TestCase
         $this->assertStringContainsString('<h1>Article Title: Eight</h1>', $files['articles/eight/index.html']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_specific_pages_when_passing_urls_as_args()
     {
         $this
@@ -92,7 +93,7 @@ class GenerateTest extends TestCase
         $this->assertStringContainsString('<h1>Articles Index Page Title</h1>', $files['articles/index.html']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_pages_to_custom_destination()
     {
         Config::set('statamic.ssg.destination', $this->destination = base_path('custom_export'));
@@ -105,7 +106,7 @@ class GenerateTest extends TestCase
         $this->cleanUpDestination();
     }
 
-    /** @test */
+    #[Test]
     public function it_clears_destination_directory_when_generating_site()
     {
         $this
@@ -117,7 +118,7 @@ class GenerateTest extends TestCase
         $this->generate();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_generate_site_without_clearing_destination_directory()
     {
         $this
@@ -129,7 +130,7 @@ class GenerateTest extends TestCase
         $this->generate(['--disable-clear' => true]);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_paginated_pages()
     {
         $this->files->put(resource_path('views/articles/index.antlers.html'), <<<'EOT'
@@ -207,7 +208,7 @@ EOT
         $this->assertStringContainsString('Prev Link: /articles/page/2', $index);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_pagination_with_custom_page_name_and_route()
     {
         // Here we'll override the `pagination_route`.
@@ -290,7 +291,7 @@ EOT
         $this->assertStringContainsString('Prev Link: /articles/p-2', $index);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_associated_paginated_pages_when_generating_only_urls_with_pagination()
     {
         $this->files->put(resource_path('views/articles/index.antlers.html'), <<<'EOT'
@@ -364,7 +365,7 @@ EOT
         $this->assertStringContainsString('Prev Link: /articles/page/2', $index);
     }
 
-    /** @test */
+    #[Test]
     public function it_enforces_trailing_slashes_when_config_enabled()
     {
         Config::set('statamic.ssg.enforce_trailing_slashes', true);
@@ -377,7 +378,7 @@ EOT
         $this->assertStringContainsString('<a href="http://cool-runnings.com/articles/three/">Three</a>', $index);
     }
 
-    /** @test */
+    #[Test]
     public function it_enforces_trailing_slashes_on_paginated_urls_when_config_enabled()
     {
         Config::set('statamic.ssg.enforce_trailing_slashes', true);
@@ -411,7 +412,7 @@ EOT
         $this->assertStringContainsString('Prev Link: /articles/page/2/', $page3);
     }
 
-    /** @test */
+    #[Test]
     public function it_still_generates_404_when_trailing_slashes_config_is_enabled()
     {
         Config::set('statamic.ssg.enforce_trailing_slashes', true);

--- a/tests/Localized/GenerateTest.php
+++ b/tests/Localized/GenerateTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Localized;
 
 use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Config;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
@@ -49,7 +50,7 @@ class GenerateTest extends TestCase
         parent::tearDown();
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_pages_for_localized_site_fixture()
     {
         $files = $this->generate();
@@ -124,7 +125,7 @@ class GenerateTest extends TestCase
         $this->assertStringContainsString('<h1>Article Title: Le Five</h1>', $files['fr/le-articles/le-five/index.html']);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_localized_paginated_pages()
     {
         $this->files->put(resource_path('views/articles/index.antlers.html'), <<<'EOT'
@@ -185,7 +186,7 @@ EOT
         $this->assertStringContainsString('Prev Link: /fr/le-articles/page/1', $index);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_localized_pagination_with_custom_page_name_and_route()
     {
         // Here we'll override the `pagination_route`.
@@ -251,7 +252,7 @@ EOT
         $this->assertStringContainsString('Prev Link: /fr/le-articles/p-1', $index);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_associated_paginated_pages_when_generating_only_localized_urls_with_pagination()
     {
         $this->files->put(resource_path('views/articles/index.antlers.html'), <<<'EOT'
@@ -311,7 +312,7 @@ EOT
         $this->assertStringContainsString('Prev Link: /fr/le-articles/page/1', $index);
     }
 
-    /** @test */
+    #[Test]
     public function it_enforces_trailing_slashes_when_config_enabled()
     {
         Config::set('statamic.ssg.enforce_trailing_slashes', true);
@@ -329,7 +330,7 @@ EOT
         $this->assertStringContainsString('<a href="http://cool-runnings.com/fr/le-articles/le-three/">Le Three</a>', $frIndex);
     }
 
-    /** @test */
+    #[Test]
     public function it_enforces_trailing_slashes_on_localized_paginated_urls_when_config_enabled()
     {
         Config::set('statamic.ssg.enforce_trailing_slashes', true);
@@ -362,7 +363,7 @@ EOT
         $this->assertStringContainsString('Prev Link: /fr/le-articles/page/1/', $frPage2);
     }
 
-    /** @test */
+    #[Test]
     public function it_still_generates_404_when_trailing_slashes_config_is_enabled()
     {
         Config::set('statamic.ssg.enforce_trailing_slashes', true);

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -3,12 +3,13 @@
 namespace Tests;
 
 use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\StaticSite\Page;
 
 class PageTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_gets_the_path()
     {
         $entry = $this->mock(Entry::class);
@@ -20,7 +21,7 @@ class PageTest extends TestCase
         $this->assertEquals('/path/to/static/foo/bar', $page->directory());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_path_of_a_url_with_a_file_extension()
     {
         $entry = $this->mock(Entry::class);
@@ -32,7 +33,7 @@ class PageTest extends TestCase
         $this->assertEquals('/path/to/static/foo/bar', $page->directory());
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_the_path_of_the_404_url()
     {
         $entry = $this->mock(Entry::class);

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Entries\Collection;
 use Statamic\Entries\Entry;
 use Statamic\Facades\Site;
@@ -10,14 +11,14 @@ use Statamic\StaticSite\Request;
 
 class RequestTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function gets_scheme()
     {
         $this->assertEquals('http', (new Request)->setConfig(['base_url' => 'http://test.com'])->getScheme());
         $this->assertEquals('https', (new Request)->setConfig(['base_url' => 'https://test.com'])->getScheme());
     }
 
-    /** @test */
+    #[Test]
     public function gets_http_host()
     {
         $this->assertEquals('test.com', (new Request)->setConfig(['base_url' => 'http://test.com'])->getHttpHost());
@@ -26,7 +27,7 @@ class RequestTest extends TestCase
         $this->assertEquals('test.com', (new Request)->setConfig(['base_url' => 'https://test.com/subdirectory/'])->getHttpHost());
     }
 
-    /** @test */
+    #[Test]
     public function gets_base_url()
     {
         $this->assertEquals('', (new Request)->setConfig(['base_url' => 'http://test.com'])->getBaseUrl());
@@ -35,7 +36,7 @@ class RequestTest extends TestCase
         $this->assertEquals('/subdirectory', (new Request)->setConfig(['base_url' => 'http://test.com/subdirectory/'])->getBaseUrl());
     }
 
-    /** @test */
+    #[Test]
     public function gets_path()
     {
         // The current site needs to be explicitly set, otherwise it will try to
@@ -55,7 +56,7 @@ class RequestTest extends TestCase
         $this->assertEquals('foo', $request->path());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_forget_query_param()
     {
         $request = new Request;


### PR DESCRIPTION
This pull request migrates PHPUnit metadata annotations to attributes, allowing us to upgrade to PHPUnit 12 in #211.