### PR TITLE
Fix glide:data_url producing blank output during generation

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -128,6 +128,14 @@ class Generator
             new Flysystem(new LocalFilesystemAdapter($this->config['destination'].'/'.$directory))
         );
 
+        // Point the glide cache disk to the same location, so that anything
+        // reading generated images back (e.g. the glide:data_url tag) will
+        // find them where the server wrote them.
+        config([
+            'statamic.assets.image_manipulation.cache' => true,
+            'statamic.assets.image_manipulation.cache_path' => $this->config['destination'].'/'.$directory,
+        ]);
+
         $this->app->bind(UrlBuilder::class, function () use ($directory) {
             return new StaticUrlBuilder($this->app[ImageGenerator::class], [
                 'route' => URL::tidy($this->config['base_url'].'/'.$directory),

--- a/tests/GenerateGlideDataUrlTest.php
+++ b/tests/GenerateGlideDataUrlTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Concerns\RunsGeneratorCommand;
+
+class GenerateGlideDataUrlTest extends TestCase
+{
+    use RunsGeneratorCommand;
+
+    const ONE_PIXEL_PNG = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+    #[Test]
+    public function it_generates_data_urls_by_reading_images_from_the_static_glide_cache()
+    {
+        $this->files->put(public_path('image.png'), base64_decode(self::ONE_PIXEL_PNG));
+
+        $this->files->put(
+            base_path('resources/views/articles/show.antlers.html'),
+            '<img src="{{ glide:data_url src="/image.png" width="50" }}">'
+        );
+
+        $files = $this->generate();
+
+        $this->assertStringContainsString('src="data:image/png;base64,', $files['articles/one/index.html']);
+    }
+}


### PR DESCRIPTION
When running `ssg:generate`, the `{{ glide:data_url }}` tag outputs nothing and logs `Unable to read file from location: …`. It only appears to work when a stale copy of the image happens to be sitting in the local glide cache from previously browsing the site.

That's because `bindGlide()` points the Glide server's cache at the static output directory, so generated images get written there — but the tag reads the image back through `Glide::cacheDisk()`, which still points at the default `storage/statamic/glide` location. Write and read disagree, so the read fails.

This PR points the glide cache disk config at the same static output location, so anything reading generated images back finds them where the server wrote them.

With `{{ glide:data_url src="/image.png" width="50" }}` in a template:

```html
<!-- before -->
<img src="">

<!-- after -->
<img src="data:image/png;base64,iVBORw0KGg…">
```

The same write/read mismatch is behind several older reports: the `{{ glide }}` tag pair reads image dimensions back through the same cache disk (via `Attributes`), so with an empty glide cache it errors out (#110, #91, #123) or returns wrong width/height (#148). Verified against this branch: a tag pair that renders `width="0" height="0"` on `4.x` with an empty cache renders the correct dimensions with this fix.

Fixes #204
Fixes #91
Fixes #110
Fixes #123
Fixes #148
