### PR TITLE
Fix translations for sites with an explicit lang

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -429,7 +429,7 @@ class Generator
         // Set the locale for dates, carbon, and for the translator.
         // This is what happens in Statamic's Localize middleware.
         setlocale(LC_TIME, $site->locale());
-        app()->setLocale($site->shortLocale());
+        app()->setLocale($site->lang());
     }
 
     protected function checkConcurrencySupport()

--- a/tests/Localized/GenerateTest.php
+++ b/tests/Localized/GenerateTest.php
@@ -47,6 +47,8 @@ class GenerateTest extends TestCase
         URL::enforceTrailingSlashes(false);
         URL::clearUrlCache();
 
+        $this->files->delete([lang_path('en_US.json'), lang_path('fr_FR.json')]);
+
         parent::tearDown();
     }
 
@@ -310,6 +312,35 @@ EOT
         $this->assertStringContainsString('Current Page: 2', $index);
         $this->assertStringContainsString('Total Pages: 2', $index);
         $this->assertStringContainsString('Prev Link: /fr/le-articles/page/1', $index);
+    }
+
+    #[Test]
+    public function it_translates_using_the_site_lang()
+    {
+        Site::setSites([
+            'default' => [
+                'name' => 'English',
+                'locale' => 'en_US',
+                'lang' => 'en_US',
+                'url' => '/',
+            ],
+            'french' => [
+                'name' => 'French',
+                'locale' => 'fr_FR',
+                'lang' => 'fr_FR',
+                'url' => '/fr/',
+            ],
+        ]);
+
+        $this->files->put(lang_path('en_US.json'), json_encode(['welcome' => 'Welcome']));
+        $this->files->put(lang_path('fr_FR.json'), json_encode(['welcome' => 'Bienvenue']));
+
+        $this->files->put(resource_path('views/default.antlers.html'), '<h1>{{ trans key="welcome" }}</h1>');
+
+        $files = $this->generate();
+
+        $this->assertStringContainsString('<h1>Welcome</h1>', $files['index.html']);
+        $this->assertStringContainsString('<h1>Bienvenue</h1>', $files['fr/index.html']);
     }
 
     #[Test]


### PR DESCRIPTION
When generating a multisite install, the generator sets the app locale to the site's *short locale*. Statamic's own `Localize` middleware uses the site's `lang` instead, which falls back to the short locale when not explicitly set.

So a site configured with an explicit lang — e.g. locale `de_CH`, lang `de_CH`, with translations in `lang/de_CH.json` — renders fine when served normally, but during a static build Laravel looks for `de.json` and the raw translation keys end up in the generated HTML.

This makes the generator match the middleware and use `$site->lang()`. Sites without an explicit lang behave exactly as before.

This also explains #166: when the short-locale lookup misses the site's translation files, Laravel serves the *fallback locale's* strings instead — so pages come out in the wrong language (or a mix, when only some keys fall back) rather than as raw keys. Reproduced on `4.x` with a `fr_FR` site and PHP lang groups: the live site renders the French strings, the static build renders the English fallback. With this fix the static build matches the live site.

Fixes #202
Fixes #166
