### PR TITLE
Fix intermittent mkdir race when generating with multiple workers

### DIFF
--- a/src/Commands/StaticSiteServe.php
+++ b/src/Commands/StaticSiteServe.php
@@ -33,7 +33,7 @@ class StaticSiteServe extends Command
     /**
      * The list of requests being handled and their start time.
      *
-     * @var array<int, \Illuminate\Support\Carbon>
+     * @var array<int, Carbon>
      */
     protected $requestsPool;
 
@@ -68,7 +68,7 @@ class StaticSiteServe extends Command
      * Start a new server process.
      *
      * @param  bool  $hasEnvironment
-     * @return \Symfony\Component\Process\Process
+     * @return Process
      */
     protected function startProcess()
     {
@@ -208,7 +208,7 @@ class StaticSiteServe extends Command
      * Get the date from the given PHP server output.
      *
      * @param  string  $line
-     * @return \Illuminate\Support\Carbon
+     * @return Carbon
      */
     protected function getDateFromLine($line)
     {

--- a/src/Page.php
+++ b/src/Page.php
@@ -65,7 +65,9 @@ class Page
         $html = $response->getContent();
 
         if (! $this->files->exists($this->directory())) {
-            $this->files->makeDirectory($this->directory(), 0755, true);
+            // Force the creation, since when running with multiple workers,
+            // another worker may have created the directory in the meantime.
+            $this->files->makeDirectory($this->directory(), 0755, true, true);
         }
 
         $this->files->put($this->path(), $html);

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -3,6 +3,8 @@
 namespace Tests;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\StaticSite\Page;
@@ -43,6 +45,34 @@ class PageTest extends TestCase
 
         $this->assertEquals('/path/to/static/404.html', $page->path());
         $this->assertEquals('/path/to/static', $page->directory());
+    }
+
+    #[Test]
+    public function it_writes_when_another_worker_creates_the_directory_after_the_existence_check()
+    {
+        // Simulate the race between parallel workers, where the directory doesn't
+        // exist when checked but has appeared by the time mkdir runs.
+        $files = new class extends Filesystem
+        {
+            public function exists($path)
+            {
+                return false;
+            }
+        };
+
+        $destination = base_path('static');
+        $files->deleteDirectory($destination);
+        $files->makeDirectory($destination.'/foo/bar', 0755, true);
+
+        $entry = $this->mock(Entry::class);
+        $entry->shouldReceive('urlWithoutRedirect')->andReturn('/foo/bar');
+        $entry->shouldReceive('toResponse')->andReturn(new Response('html'));
+
+        $page = new Page($files, ['destination' => $destination], $entry);
+
+        $page->generate(Request::create('/foo/bar'));
+
+        $this->assertFileExists($destination.'/foo/bar/index.html');
     }
 
     private function page($entry, $config)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,9 @@ namespace Tests;
 
 use Illuminate\Filesystem\Filesystem;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
+use Statamic\Providers\StatamicServiceProvider;
 use Statamic\Statamic;
+use Wilderborn\Partyline\ServiceProvider;
 
 class TestCase extends OrchestraTestCase
 {
@@ -14,8 +16,8 @@ class TestCase extends OrchestraTestCase
     protected function getPackageProviders($app)
     {
         return [
-            \Statamic\Providers\StatamicServiceProvider::class,
-            \Wilderborn\Partyline\ServiceProvider::class,
+            StatamicServiceProvider::class,
+            ServiceProvider::class,
             \Statamic\StaticSite\ServiceProvider::class,
         ];
     }


### PR DESCRIPTION
When generating with multiple workers, a page would intermittently fail with:

```
[✘] /fr (mkdir(): File exists)
```

Two workers can race on the same output directory: one checks that it doesn't exist, another creates it in the meantime (e.g. while writing a child page like `/fr/stories/...`), and the first worker's `mkdir` then throws. Since pages are shuffled across workers, it's timing-dependent — on a small 13-page multisite it failed 5 out of 20 runs with `--workers=4`.

This forces the directory creation, so an already-existing directory is treated as success. Genuine failures (permissions etc.) still surface through the `put()` right after. With the fix, the same 20-run loop passes cleanly.

Co-Authored-By: Claude <noreply@anthropic.com>